### PR TITLE
feat(monuments): implemented endpoints to pagination, search, filter

### DIFF
--- a/content/src/main/java/pt/estga/content/repositories/MonumentRepository.java
+++ b/content/src/main/java/pt/estga/content/repositories/MonumentRepository.java
@@ -1,10 +1,12 @@
 package pt.estga.content.repositories;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import pt.estga.content.entities.Monument;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,4 +22,9 @@ public interface MonumentRepository extends JpaRepository<Monument, Long> {
     List<Monument> findByCoordinatesInRange(@Param("lat") double latitude, @Param("lon") double longitude, @Param("range") double range);
 
     Optional<Monument> findByLatitudeAndLongitude(double latitude, double longitude);
+
+    Page<Monument> findByNameContainingIgnoreCase(String name, Pageable pageable);
+
+    Page<Monument> findByCityIgnoreCase(String city, Pageable pageable);
+
 }

--- a/content/src/main/java/pt/estga/content/services/MonumentService.java
+++ b/content/src/main/java/pt/estga/content/services/MonumentService.java
@@ -23,6 +23,12 @@ public interface MonumentService {
 
     List<Monument> findLatest(int limit);
 
+    long count();
+
+    Page<Monument> searchByName(String query, Pageable pageable);
+
+    Page<Monument> findByCity(String city, Pageable pageable);
+
     Monument create(Monument monument);
 
     Monument update(Monument monument);

--- a/content/src/main/java/pt/estga/content/services/MonumentServiceHibernateImpl.java
+++ b/content/src/main/java/pt/estga/content/services/MonumentServiceHibernateImpl.java
@@ -54,6 +54,21 @@ public class MonumentServiceHibernateImpl implements MonumentService {
     }
 
     @Override
+    public long count() {
+        return repository.count();
+    }
+
+    @Override
+    public Page<Monument> searchByName(String query, Pageable pageable) {
+        return repository.findByNameContainingIgnoreCase(query, pageable);
+    }
+
+    @Override
+    public Page<Monument> findByCity(String city, Pageable pageable) {
+        return repository.findByCityIgnoreCase(city, pageable);
+    }
+
+    @Override
     public Monument create(Monument monument) {
         return repository.save(monument);
     }


### PR DESCRIPTION
# **feat(monuments): Implement pagination, search, and filtering endpoints**

## Overview

This Pull Request introduces a set of improvements to the *Monuments*
module, adding structured and scalable access to monument data through
pagination, search, and filtering endpoints.\
It also enhances consistency across the API using standardized DTO
mapping and improved sorting logic.

------------------------------------------------------------------------

## New Endpoints & Features

### **1. Paginated List of Monuments**

**`GET /api/v1/monuments`**\
- Supports `page` and `size` parameters.\
- Returns paginated `MonumentResponseDto` entries.

------------------------------------------------------------------------

### **2. Search Monuments by Name**

**`GET /api/v1/monuments/search`**\
- Filters by `query` (partial match).\
- Includes pagination + alphabetical sorting (`Sort.by("name")`).

------------------------------------------------------------------------

### **3. Filter Monuments by City**

**`GET /api/v1/monuments/filter`**\
- Retrieves monuments from a specific city.\
- Pagination and alphabetical sorting included.

------------------------------------------------------------------------

### **4. Count Total Monuments**

**`GET /api/v1/monuments/count`**\
- Returns the total number of monuments in the system.

------------------------------------------------------------------------

## Additional Improvements

-   Standardized DTO transformations across all controller actions.\
-   Added defensive handling for the `/latest` endpoint (`safeLimit`).\
-   Introduced predictable sorting on search and filter endpoints.

------------------------------------------------------------------------

## Summary

This PR enhances the Monuments API with robust and scalable endpoints,
improving usability for clients while ensuring consistency and
maintainability across the codebase.
