### PR TITLE
refactor(auth, user, report): enhance validation and error handling for authentication and user input

### DIFF
--- a/auth/src/main/java/pt/estga/auth/controllers/AuthenticationController.java
+++ b/auth/src/main/java/pt/estga/auth/controllers/AuthenticationController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -43,6 +44,7 @@ public class AuthenticationController {
     })
     @PostMapping("/register")
     public ResponseEntity<?> register(
+            @Valid
             @RequestBody(description = "User registration details including username, email, and password.",
                          required = true,
                          content = @Content(schema = @Schema(implementation = RegisterRequestDto.class)))

--- a/auth/src/main/java/pt/estga/auth/dtos/RegisterRequestDto.java
+++ b/auth/src/main/java/pt/estga/auth/dtos/RegisterRequestDto.java
@@ -1,11 +1,24 @@
 package pt.estga.auth.dtos;
 
-import lombok.*;
+import lombok.Builder;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Builder
 public record RegisterRequestDto(
+        @NotBlank(message = "First name is required")
+        @Size(max = 50, message = "First name must be at most 50 characters")
         String firstName,
+
+        @NotBlank(message = "Last name is required")
+        @Size(max = 50, message = "Last name must be at most 50 characters")
         String lastName,
+
+        @NotBlank(message = "Username is required")
+        @Size(max = 30, message = "Username must be at most 30 characters")
         String username,
+
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 100, message = "Password must be between 8 and 100 characters")
         String password
 ) { }

--- a/auth/src/main/java/pt/estga/auth/services/AuthenticationServiceSpringImpl.java
+++ b/auth/src/main/java/pt/estga/auth/services/AuthenticationServiceSpringImpl.java
@@ -17,6 +17,7 @@ import pt.estga.security.services.AccessTokenService;
 import pt.estga.security.services.JwtService;
 import pt.estga.security.services.RefreshTokenService;
 import pt.estga.shared.exceptions.EmailVerificationRequiredException;
+import pt.estga.shared.exceptions.InvalidCredentialsException;
 import pt.estga.shared.exceptions.UsernameAlreadyTakenException;
 import pt.estga.user.entities.User;
 import pt.estga.user.entities.UserContact;
@@ -96,7 +97,7 @@ public class AuthenticationServiceSpringImpl implements AuthenticationService {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(usernameOrContact, password));
         } catch (AuthenticationException e) {
             log.warn("Authentication failed for user: {}", usernameOrContact, e);
-            return Optional.empty();
+            throw new InvalidCredentialsException();
         }
 
         User user = userService.findByUsername(usernameOrContact)

--- a/report/src/main/java/pt/estga/report/controllers/ReportController.java
+++ b/report/src/main/java/pt/estga/report/controllers/ReportController.java
@@ -1,6 +1,7 @@
 package pt.estga.report.controllers;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +26,7 @@ public class ReportController {
 
     @PostMapping
     public ReportResponseDto createReport(
+            @Valid
             @RequestBody ReportRequestDto dto
     ) {
         Long userId = SecurityUtils.getCurrentUserId().orElseThrow();

--- a/report/src/main/java/pt/estga/report/dtos/ReportRequestDto.java
+++ b/report/src/main/java/pt/estga/report/dtos/ReportRequestDto.java
@@ -10,9 +10,9 @@ public record ReportRequestDto(
         Long targetId,
         @NotNull
         TargetType targetType,
-        @NotNull
+        @NotNull(message = "Reason is required")
         ReportReason reason,
-        @Size(max = 1000)
+        @Size(min = 10, max = 1000, message = "Description must be at most 1000 characters")
         String description
 ) {}
 

--- a/shared/src/main/java/pt/estga/shared/exceptions/GlobalExceptionHandler.java
+++ b/shared/src/main/java/pt/estga/shared/exceptions/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import pt.estga.shared.dtos.MessageResponseDto;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -16,6 +17,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IOException.class)
     public ResponseEntity<String> handleIOException(IOException ex) {
         return new ResponseEntity<>("File processing error: " + ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+
+    @ExceptionHandler(InvalidCredentialsException.class)
+    public ResponseEntity<MessageResponseDto> handleInvalidCredentials(
+            InvalidCredentialsException ex
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new MessageResponseDto(ex.getMessage()));
     }
 
     @ExceptionHandler(RuntimeException.class) // Catch generic RuntimeException for now, can be refined

--- a/shared/src/main/java/pt/estga/shared/exceptions/InvalidCredentialsException.java
+++ b/shared/src/main/java/pt/estga/shared/exceptions/InvalidCredentialsException.java
@@ -1,0 +1,11 @@
+package pt.estga.shared.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class InvalidCredentialsException extends RuntimeException {
+    public InvalidCredentialsException() {
+        super("Invalid username or password.");
+    }
+}

--- a/user/src/main/java/pt/estga/user/dtos/PasswordChangeRequestDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/PasswordChangeRequestDto.java
@@ -1,9 +1,14 @@
 package pt.estga.user.dtos;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record PasswordChangeRequestDto(
-        @NotBlank String oldPassword,
-        @NotBlank String newPassword
-) {
-}
+        @NotBlank(message = "Current password is required")
+        @Size(min = 8, max = 100, message = "Current password must be between 8 and 100 characters")
+        String oldPassword,
+
+        @NotBlank(message = "New password is required")
+        @Size(min = 8, max = 100, message = "New password must be between 8 and 100 characters")
+        String newPassword
+) {}

--- a/user/src/main/java/pt/estga/user/dtos/PasswordSetRequestDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/PasswordSetRequestDto.java
@@ -1,6 +1,10 @@
 package pt.estga.user.dtos;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
-public record PasswordSetRequestDto(@NotBlank String newPassword) {
-}
+public record PasswordSetRequestDto(
+        @NotBlank(message = "Password is required")
+        @Size(min = 8, max = 100, message = "Password must be between 8 and 100 characters")
+        String newPassword
+) {}

--- a/user/src/main/java/pt/estga/user/dtos/ProfileUpdateRequestDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/ProfileUpdateRequestDto.java
@@ -4,7 +4,12 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record ProfileUpdateRequestDto(
-        @NotBlank() @Size(max = 100) String firstName,
-        @NotBlank() @Size(max = 100) String lastName
-) {
-}
+
+        @NotBlank(message = "First name is required")
+        @Size(max = 50, message = "First name must be at most 50 characters")
+        String firstName,
+
+        @NotBlank(message = "Last name is required")
+        @Size(max = 50, message = "Last name must be at most 50 characters")
+        String lastName
+) {}

--- a/user/src/main/java/pt/estga/user/services/UserContactServiceImpl.java
+++ b/user/src/main/java/pt/estga/user/services/UserContactServiceImpl.java
@@ -126,7 +126,7 @@ public class UserContactServiceImpl implements UserContactService {
     public UserContact setAsPrimary(UserContact userContact) {
         log.info("Setting primary user contact: {}", userContact);
 
-        if (!userContact.getPrimary()) {
+        if (!userContact.getVerified()) {
             throw new IllegalStateException("Contact must be verified before being set as primary.");
         }
 


### PR DESCRIPTION
This pull request focuses on improving validation and error handling across authentication, user, and report modules. The main changes introduce more thorough input validation using Jakarta Bean Validation annotations, enhance error reporting for authentication failures, and clarify exception handling. These improvements aim to provide clearer feedback to API consumers and enforce stricter data integrity.

**Validation Enhancements:**

* Added Jakarta Bean Validation annotations (e.g., `@NotBlank`, `@Size`) to DTOs such as `RegisterRequestDto`, `PasswordChangeRequestDto`, `PasswordSetRequestDto`, `ProfileUpdateRequestDto`, and `ReportRequestDto` to enforce field requirements and provide user-friendly validation messages. [[1]](diffhunk://#diff-75d3c5e22ed4eb6d3c503abdc627755e37e16d2614c55e822f1f57bab2145e20L3-R22) [[2]](diffhunk://#diff-a7dfa0dabcd3e78bd9ee07b86ab7017774cd6566b063e8458913af803067ba0fR4-R14) [[3]](diffhunk://#diff-7a6ca4033f92b3ff5bbf0ffb76fc5ca49b253d5653c3d01917ebae1ee64cf48dR4-R10) [[4]](diffhunk://#diff-1c031751024f0f25b203b29eb02828c5e16f672dbee2234938e1a53a0a06b733L7-R15) [[5]](diffhunk://#diff-4ff2506448bae7a400553242d5c267395b6bc60bf8f115dbf552aa5f90c92d69L13-R15)
* Updated controller methods in `AuthenticationController` and `ReportController` to use the `@Valid` annotation, ensuring that incoming requests are validated according to the new constraints. [[1]](diffhunk://#diff-efb926527f3fa72e8f22cdfcf006055e5ea37e98bf0d944c071065bc68db4e8eR10) [[2]](diffhunk://#diff-efb926527f3fa72e8f22cdfcf006055e5ea37e98bf0d944c071065bc68db4e8eR47) [[3]](diffhunk://#diff-b88233c4ae7038f45cdafde59bd2c3edd1f922861843a74de6e04e28c85d934aR4) [[4]](diffhunk://#diff-b88233c4ae7038f45cdafde59bd2c3edd1f922861843a74de6e04e28c85d934aR29)

**Authentication and Exception Handling:**

* Introduced a new `InvalidCredentialsException` to represent authentication failures, replacing the previous approach of returning empty optionals. This exception is now thrown when authentication fails due to invalid credentials. [[1]](diffhunk://#diff-96931026d86051934cf237f43ad4daa71505581e35b797f538f1425b1f296927R1-R11) [[2]](diffhunk://#diff-d23bc014fdf74a918efb2a1fddd069d18f1dd7fa45b5044b77ec9bcb2ef1b507R20) [[3]](diffhunk://#diff-d23bc014fdf74a918efb2a1fddd069d18f1dd7fa45b5044b77ec9bcb2ef1b507L99-R100)
* Updated the global exception handler to catch `InvalidCredentialsException` and return a structured `MessageResponseDto` with a 401 Unauthorized status, improving error clarity for clients. [[1]](diffhunk://#diff-8ac6a207154c707871086786e5878178bcca4a188103c27df6ad2194fd2f4bdeR8) [[2]](diffhunk://#diff-8ac6a207154c707871086786e5878178bcca4a188103c27df6ad2194fd2f4bdeR22-R30)

**Business Logic Fix:**

* Corrected logic in `UserContactServiceImpl` to ensure only verified contacts can be set as primary, preventing unverified contacts from being promoted.