### PR TITLE
feat(proposal): add user statistics endpoint and DTO for MarkOccurrenceProposal

### DIFF
--- a/proposal/src/main/java/pt/estga/proposal/controllers/MarkOccurrenceProposalController.java
+++ b/proposal/src/main/java/pt/estga/proposal/controllers/MarkOccurrenceProposalController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pt.estga.proposal.dtos.MarkOccurrenceProposalDto;
 import pt.estga.proposal.dtos.MarkOccurrenceProposalListDto;
+import pt.estga.proposal.dtos.MarkOccurrenceProposalStatsDto;
 import pt.estga.proposal.entities.MarkOccurrenceProposal;
 import pt.estga.proposal.mappers.MarkOccurrenceProposalMapper;
 import pt.estga.proposal.services.MarkOccurrenceProposalService;
@@ -42,6 +43,14 @@ public class MarkOccurrenceProposalController {
         User user = User.builder().id(userId).build();
         Page<MarkOccurrenceProposal> proposals = proposalService.findByUser(user, PageRequest.of(page, size));
         return proposals.map(markOccurrenceProposalMapper::toDto);
+    }
+
+    @GetMapping("/user/{userId}/stats")
+    public ResponseEntity<MarkOccurrenceProposalStatsDto> getUserStats(
+            @PathVariable Long userId
+    ) {
+        User user = User.builder().id(userId).build();
+        return ResponseEntity.ok(proposalService.getStatsByUser(user));
     }
 
     @GetMapping("/{proposalId}")

--- a/proposal/src/main/java/pt/estga/proposal/dtos/MarkOccurrenceProposalStatsDto.java
+++ b/proposal/src/main/java/pt/estga/proposal/dtos/MarkOccurrenceProposalStatsDto.java
@@ -1,0 +1,7 @@
+package pt.estga.proposal.dtos;
+
+public record MarkOccurrenceProposalStatsDto(
+        long accepted,
+        long underReview,
+        long rejected
+) {}

--- a/proposal/src/main/java/pt/estga/proposal/repositories/MarkOccurrenceProposalRepository.java
+++ b/proposal/src/main/java/pt/estga/proposal/repositories/MarkOccurrenceProposalRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import pt.estga.proposal.dtos.MarkOccurrenceProposalStatsDto;
 import pt.estga.proposal.entities.MarkOccurrenceProposal;
 import pt.estga.proposal.enums.ProposalStatus;
 
@@ -25,6 +26,17 @@ public interface MarkOccurrenceProposalRepository extends JpaRepository<MarkOccu
     List<MarkOccurrenceProposal> findByPriorityGreaterThanEqual(Integer priority);
 
     Optional<MarkOccurrenceProposal> findFirstBySubmitted(boolean submitted);
+
+    @Query("""
+    SELECT new pt.estga.proposal.dtos.MarkOccurrenceProposalStatsDto(
+        SUM(CASE WHEN p.status IN ('AUTO_ACCEPTED', 'MANUALLY_ACCEPTED') THEN 1 ELSE 0 END),
+        SUM(CASE WHEN p.status IN ('SUBMITTED', 'UNDER_REVIEW') THEN 1 ELSE 0 END),
+        SUM(CASE WHEN p.status IN ('AUTO_REJECTED', 'MANUALLY_REJECTED') THEN 1 ELSE 0 END)
+    )
+    FROM MarkOccurrenceProposal p
+    WHERE p.submittedById = :userId
+    """)
+    MarkOccurrenceProposalStatsDto getStatsByUserId(@Param("userId") Long userId);
 
     long countBySubmittedByIdAndStatusIn(Long submittedById, Collection<ProposalStatus> statuses);
 

--- a/proposal/src/main/java/pt/estga/proposal/services/MarkOccurrenceProposalService.java
+++ b/proposal/src/main/java/pt/estga/proposal/services/MarkOccurrenceProposalService.java
@@ -2,6 +2,7 @@ package pt.estga.proposal.services;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import pt.estga.proposal.dtos.MarkOccurrenceProposalStatsDto;
 import pt.estga.proposal.entities.MarkOccurrenceProposal;
 import pt.estga.user.entities.User;
 
@@ -22,6 +23,8 @@ public interface MarkOccurrenceProposalService {
     MarkOccurrenceProposal update(MarkOccurrenceProposal proposal);
 
     void delete(MarkOccurrenceProposal proposal);
+
+    MarkOccurrenceProposalStatsDto getStatsByUser(User user);
 
     long countApprovedProposalsByUserId(Long userId);
 

--- a/proposal/src/main/java/pt/estga/proposal/services/MarkOccurrenceProposalServiceHibernateImpl.java
+++ b/proposal/src/main/java/pt/estga/proposal/services/MarkOccurrenceProposalServiceHibernateImpl.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import pt.estga.proposal.dtos.MarkOccurrenceProposalStatsDto;
 import pt.estga.proposal.entities.MarkOccurrenceProposal;
 import pt.estga.proposal.enums.ProposalStatus;
 import pt.estga.proposal.repositories.MarkOccurrenceProposalRepository;
@@ -55,6 +56,10 @@ public class MarkOccurrenceProposalServiceHibernateImpl implements MarkOccurrenc
         repository.delete(proposal);
     }
 
+    @Override
+    public MarkOccurrenceProposalStatsDto getStatsByUser(User user) {
+        return repository.getStatsByUserId(user.getId());
+    }
 
     @Override
     public long countApprovedProposalsByUserId(Long userId) {


### PR DESCRIPTION
This pull request adds a new feature to provide statistics about proposal statuses for a given user. The main changes introduce a new DTO to represent these statistics, a repository query to efficiently fetch them, and a controller endpoint to expose this data via the API.

**New feature: User proposal statistics**

* Added a new endpoint `/user/{userId}/stats` to `MarkOccurrenceProposalController` that returns a summary of accepted, under review, and rejected proposals for a user.
* Created the `MarkOccurrenceProposalStatsDto` record to encapsulate the counts of accepted, under review, and rejected proposals.

**Repository and service layer support**

* Implemented a custom JPA query in `MarkOccurrenceProposalRepository` to efficiently aggregate proposal statistics by user.
* Added the `getStatsByUser` method to the `MarkOccurrenceProposalService` interface and its Hibernate implementation, delegating to the repository query. [[1]](diffhunk://#diff-0b3775830274aff007c436c9cdd644c01e48881f55560eb2367997d62261c04cR27-R28) [[2]](diffhunk://#diff-bf8435a6f24ac182fc2e067ce02b7ac87eaf8b41184aa1bcd944346a071e5b36R59-R62)