### PR TITLE
refactor(proposal): update pagination size and enhance proposal retrieval methods

### DIFF
--- a/proposal/src/main/java/pt/estga/proposal/controllers/MarkOccurrenceProposalController.java
+++ b/proposal/src/main/java/pt/estga/proposal/controllers/MarkOccurrenceProposalController.java
@@ -27,7 +27,7 @@ public class MarkOccurrenceProposalController {
     public Page<MarkOccurrenceProposalListDto> findByUser(
             @PathVariable Long userId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "6") int size
     ) {
         User user = User.builder().id(userId).build();
         Page<MarkOccurrenceProposal> proposals = proposalService.findByUser(user, PageRequest.of(page, size));
@@ -38,7 +38,7 @@ public class MarkOccurrenceProposalController {
     public Page<MarkOccurrenceProposalDto> findDetailedByUser(
             @PathVariable Long userId,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "6") int size
     ) {
         User user = User.builder().id(userId).build();
         Page<MarkOccurrenceProposal> proposals = proposalService.findByUser(user, PageRequest.of(page, size));

--- a/proposal/src/main/java/pt/estga/proposal/controllers/MarkOccurrenceProposalModerationController.java
+++ b/proposal/src/main/java/pt/estga/proposal/controllers/MarkOccurrenceProposalModerationController.java
@@ -24,7 +24,7 @@ import pt.estga.shared.interfaces.AuthenticatedPrincipal;
 import java.util.List;
 
 @RestController
-@RequestMapping("api/v1/proposals/mark-occurrences")
+@RequestMapping("api/v1/proposals/mark-occurrences/moderation")
 @RequiredArgsConstructor
 @PreAuthorize("hasAuthority('REVIEWER')")
 @Tag(name = "Proposal Moderation", description = "Endpoints for proposal moderation actions.")

--- a/proposal/src/main/java/pt/estga/proposal/dtos/MarkOccurrenceProposalDto.java
+++ b/proposal/src/main/java/pt/estga/proposal/dtos/MarkOccurrenceProposalDto.java
@@ -2,8 +2,8 @@ package pt.estga.proposal.dtos;
 
 import pt.estga.content.dtos.MarkDto;
 import pt.estga.content.dtos.MonumentResponseDto;
-import pt.estga.file.dtos.MediaFileDto;
 import pt.estga.proposal.enums.ProposalStatus;
+import pt.estga.proposal.enums.SubmissionSource;
 
 public record MarkOccurrenceProposalDto(
         Long id,
@@ -16,6 +16,7 @@ public record MarkOccurrenceProposalDto(
         MarkDto existingMark,
         boolean newMark,
         String userNotes,
+        SubmissionSource submissionSource,
         boolean isSubmitted,
         ProposalStatus status
 ) {

--- a/proposal/src/main/java/pt/estga/proposal/repositories/MarkOccurrenceProposalRepository.java
+++ b/proposal/src/main/java/pt/estga/proposal/repositories/MarkOccurrenceProposalRepository.java
@@ -23,6 +23,12 @@ public interface MarkOccurrenceProposalRepository extends JpaRepository<MarkOccu
             "WHERE p.submittedById = :userId")
     Page<MarkOccurrenceProposal> findBySubmittedById(@Param("userId") Long userId, Pageable pageable);
 
+    @Query("SELECT p FROM MarkOccurrenceProposal p " +
+            "LEFT JOIN FETCH p.existingMonument " +
+            "LEFT JOIN FETCH p.existingMark " +
+            "WHERE p.id = :id")
+    Optional<MarkOccurrenceProposal> findByIdDetailed(@Param("id") Long id);
+
     List<MarkOccurrenceProposal> findByPriorityGreaterThanEqual(Integer priority);
 
     Optional<MarkOccurrenceProposal> findFirstBySubmitted(boolean submitted);

--- a/proposal/src/main/java/pt/estga/proposal/services/MarkOccurrenceProposalServiceHibernateImpl.java
+++ b/proposal/src/main/java/pt/estga/proposal/services/MarkOccurrenceProposalServiceHibernateImpl.java
@@ -27,7 +27,7 @@ public class MarkOccurrenceProposalServiceHibernateImpl implements MarkOccurrenc
 
     @Override
     public Optional<MarkOccurrenceProposal> findById(Long id) {
-        return repository.findById(id);
+        return repository.findByIdDetailed(id);
     }
 
     @Override


### PR DESCRIPTION
This pull request introduces several improvements to the proposal moderation API and enhances the detail level of proposal retrieval. The most notable changes are the addition of a detailed proposal fetch method, updates to DTOs to include the submission source, and a modification to the moderation endpoint path. Additionally, pagination defaults have been adjusted for user proposal queries.

**API and Endpoint Improvements:**

* Changed the moderation controller's base path to `api/v1/proposals/mark-occurrences/moderation` for clearer endpoint separation.

**Proposal Detail Enhancements:**

* Added a new repository method `findByIdDetailed` in `MarkOccurrenceProposalRepository` to fetch proposals with their associated monument and mark details, improving the richness of data returned for detailed views.
* Updated the service layer to use `findByIdDetailed` instead of the standard `findById` for fetching proposals, ensuring detailed information is always retrieved.

**DTO Improvements:**

* Added the `submissionSource` field to `MarkOccurrenceProposalDto`, allowing clients to see how a proposal was submitted. [[1]](diffhunk://#diff-5f50a818d6329790232f332b35ad16d84399b0decfc51538357c18556e1dd6b9R19) [[2]](diffhunk://#diff-5f50a818d6329790232f332b35ad16d84399b0decfc51538357c18556e1dd6b9L5-R6)

**Pagination Defaults:**

* Changed the default page size for user proposal queries from 10 to 6 in both the list and detailed endpoints, likely to improve UI performance or usability. [[1]](diffhunk://#diff-024200b7f4a6f64a6ea62fff0cf734a3602d638f99e3428249882f9d962e2f3fL30-R30) [[2]](diffhunk://#diff-024200b7f4a6f64a6ea62fff0cf734a3602d638f99e3428249882f9d962e2f3fL41-R41)