### PR TITLE
Feature/identity

### DIFF
--- a/boot/src/main/java/pt/estga/boot/config/CacheConfig.java
+++ b/boot/src/main/java/pt/estga/boot/config/CacheConfig.java
@@ -6,18 +6,25 @@ import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class CacheConfig {
 
+    private static final List<String> CACHE_NAMES = List.of(
+            "conversations",
+            "user_provisioning"
+    );
+
     @Bean
     public CacheManager cacheManager() {
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager("conversations");
+
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+        cacheManager.setCacheNames(CACHE_NAMES);
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .expireAfterWrite(10, TimeUnit.MINUTES)
                 .maximumSize(1000)
-                .weakKeys()
                 .recordStats());
         return cacheManager;
     }

--- a/boot/src/main/java/pt/estga/boot/config/KeycloakJwtAuthenticationConverter.java
+++ b/boot/src/main/java/pt/estga/boot/config/KeycloakJwtAuthenticationConverter.java
@@ -29,6 +29,11 @@ public class KeycloakJwtAuthenticationConverter implements Converter<Jwt, Abstra
         KeycloakIdentitySnapshot snapshot = KeycloakIdentitySnapshot.fromClaims(jwt.getClaims());
         User user = jitProvisioningService.resolveOrProvision(snapshot);
 
+        // CRITICAL: Block users disabled in YOUR database
+        if (!user.isEnabled() || user.isAccountLocked()) {
+            throw new org.springframework.security.authentication.DisabledException("User account is inactive.");
+        }
+
         // Build AppPrincipal from resolved user
         AppPrincipal principal = AppPrincipal.builder()
                 .id(user.getId())

--- a/user/src/main/java/pt/estga/user/controllers/AccountController.java
+++ b/user/src/main/java/pt/estga/user/controllers/AccountController.java
@@ -9,13 +9,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-import pt.estga.file.entities.MediaFile;
 import pt.estga.file.services.MediaService;
 import pt.estga.shared.interfaces.AuthenticatedPrincipal;
 import pt.estga.sharedweb.dtos.MessageResponseDto;
@@ -23,8 +20,6 @@ import pt.estga.user.dtos.*;
 import pt.estga.user.entities.User;
 import pt.estga.user.mappers.UserMapper;
 import pt.estga.user.services.UserService;
-
-import java.io.IOException;
 
 @RestController
 @RequestMapping("/api/v1/account")
@@ -65,26 +60,8 @@ public class AccountController {
             @Valid @RequestBody ProfileUpdateRequestDto request) {
         User user = userService.findById(principal.getId()).orElseThrow();
         mapper.update(user, request);
-
-        if (request.photoId() != null) {
-            mediaService.findById(request.photoId()).ifPresent(user::setPhoto);
-        }
-
         userService.update(user);
         return ResponseEntity.ok(MessageResponseDto.success("Your profile has been updated successfully."));
-    }
-
-
-    @PostMapping(value = "/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<UserDto> uploadPhoto(
-            @AuthenticationPrincipal AuthenticatedPrincipal principal,
-            @RequestParam("file") MultipartFile file
-    ) throws IOException {
-        User user = userService.findById(principal.getId()).orElseThrow();
-        MediaFile mediaFile = mediaService.save(file.getInputStream(), file.getOriginalFilename());
-        user.setPhoto(mediaFile);
-        User updatedUser = userService.update(user);
-        return ResponseEntity.ok(mapper.toDto(updatedUser));
     }
 
     @Operation(summary = "Delete user account", description = "Deletes the authenticated user's account.")

--- a/user/src/main/java/pt/estga/user/dtos/ProfileUpdateRequestDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/ProfileUpdateRequestDto.java
@@ -11,7 +11,6 @@ public record ProfileUpdateRequestDto(
 
         @NotBlank(message = "Last name is required")
         @Size(max = 50, message = "Last name must be at most 50 characters")
-        String lastName,
+        String lastName
 
-        Long photoId
 ) {}

--- a/user/src/main/java/pt/estga/user/entities/User.java
+++ b/user/src/main/java/pt/estga/user/entities/User.java
@@ -3,9 +3,10 @@ package pt.estga.user.entities;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
-import pt.estga.file.entities.MediaFile;
 import pt.estga.shared.enums.UserRole;
 
+import java.io.Serial;
+import java.io.Serializable;
 import java.time.Instant;
 import java.util.Objects;
 
@@ -16,7 +17,10 @@ import java.util.Objects;
 @Getter
 @Setter
 @Builder
-public class User {
+public class User implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue

--- a/user/src/main/java/pt/estga/user/entities/User.java
+++ b/user/src/main/java/pt/estga/user/entities/User.java
@@ -48,9 +48,6 @@ public class User {
     @Builder.Default
     private boolean emailVerified = false;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
-    private MediaFile photo;
-
     @Enumerated(EnumType.STRING)
     private UserRole role;
 

--- a/user/src/main/java/pt/estga/user/entities/User.java
+++ b/user/src/main/java/pt/estga/user/entities/User.java
@@ -29,6 +29,13 @@ public class User {
     @Column(unique = true)
     private String email;
 
+    /**
+     * External Keycloak subject identifier (subclaim).
+     * <p>
+     * This value is used only as an external lookup key for JIT provisioning and
+     * account linking. Internal domain relationships should reference the local
+     * database id (Long) to preserve local data ownership and portability.
+     */
     @Column(name = "keycloak_sub", unique = true)
     private String keycloakSub;
 
@@ -54,25 +61,21 @@ public class User {
     @CreationTimestamp
     private Instant createdAt;
 
+    private Instant lastLoginAt;
+
     @Override
     public boolean equals(Object o) {
+        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return accountLocked == user.accountLocked
-                && enabled == user.enabled
-                && emailVerified == user.emailVerified
-                && Objects.equals(id, user.id)
-                && Objects.equals(firstName, user.firstName)
-                && Objects.equals(lastName, user.lastName)
-                && Objects.equals(username, user.username)
-                && Objects.equals(email, user.email)
-                && Objects.equals(keycloakSub, user.keycloakSub)
-                && role == user.role
-                && Objects.equals(createdAt, user.createdAt);
+        if (keycloakSub != null && user.keycloakSub != null) {
+            return Objects.equals(keycloakSub, user.keycloakSub);
+        }
+        return Objects.equals(id, user.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, firstName, lastName, username, email, keycloakSub, emailVerified, role, accountLocked, enabled, createdAt);
+        return keycloakSub != null ? Objects.hash(keycloakSub) : Objects.hash(id);
     }
 }

--- a/user/src/main/java/pt/estga/user/mappers/UserMapper.java
+++ b/user/src/main/java/pt/estga/user/mappers/UserMapper.java
@@ -13,13 +13,10 @@ public interface UserMapper {
 
     UserDto toDto(User user);
 
-    @Mapping(target = "photoId", source = "photo.id")
     UserPublicDto toPublicDto(User user);
 
-    @Mapping(target = "photo", ignore = true)
     User toEntity(UserDto dto);
 
-    @Mapping(target = "photo", ignore = true)
     void update(@MappingTarget User user, ProfileUpdateRequestDto dto);
 
 }

--- a/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
+++ b/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
@@ -101,15 +101,13 @@ public class KeycloakJitProvisioningService {
             }
         }
 
-        // Keycloak subject: ensure local DB stores the external lookup key; persist when changed
+        // Keycloak subject: maintain link
         if (snapshot.sub() != null && !snapshot.sub().equals(user.getKeycloakSub())) {
             user.setKeycloakSub(snapshot.sub());
             changed = true;
         }
 
-        // Do not overwrite local firstName/lastName to maintain local data ownership
-
-        // Update last login timestamp only when it's stale to avoid frequent DB writes
+        // Update last login timestamp
         Instant now = Instant.now();
         long minutesSinceLast = user.getLastLoginAt() == null ? Long.MAX_VALUE : Duration.between(user.getLastLoginAt(), now).toMinutes();
         if (user.getLastLoginAt() == null || minutesSinceLast >= 5) {
@@ -119,7 +117,6 @@ public class KeycloakJitProvisioningService {
 
         if (changed) {
             User updated = userService.update(user);
-            // Evict cache via the proxied self reference so @CacheEvict takes effect
             if (self != null) {
                 self.evictProvisioningCache(updated.getKeycloakSub());
             }

--- a/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
+++ b/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
@@ -7,6 +7,8 @@ import pt.estga.shared.enums.UserRole;
 import pt.estga.user.dtos.KeycloakIdentitySnapshot;
 import pt.estga.user.entities.User;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 public class KeycloakJitProvisioningService {
@@ -76,22 +78,22 @@ public class KeycloakJitProvisioningService {
     }
 
     private String resolveUsername(KeycloakIdentitySnapshot snapshot) {
+        // 1. Pick the best starting point
         String base = snapshot.preferredUsername();
-
         if (base == null || base.isBlank()) {
-            if (snapshot.email() != null && snapshot.email().contains("@")) {
-                base = snapshot.email().substring(0, snapshot.email().indexOf('@'));
-            } else {
-                base = "kc_" + snapshot.sub().substring(0, Math.min(snapshot.sub().length(), 8));
-            }
+            base = (snapshot.email() != null && snapshot.email().contains("@"))
+                    ? snapshot.email().split("@")[0]
+                    : "user";
         }
 
-        String candidate = base;
-        int i = 1;
-        while (userService.existsByUsername(candidate)) {
-            candidate = base + i++;
-        }
+        // 2. Sanitize: Remove non-alphanumeric characters (keep it clean)
+        base = base.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
 
-        return candidate;
+        // 3. Extract deterministic suffix from sub
+        // Using 8 chars gives 16^8 (~4.2 billion) possibilities, safe for collisions
+        String sub = snapshot.sub() != null ? snapshot.sub() : UUID.randomUUID().toString();
+        String suffix = sub.substring(0, Math.min(sub.length(), 8));
+
+        return base + "_" + suffix;
     }
 }

--- a/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
+++ b/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
@@ -1,22 +1,38 @@
 package pt.estga.user.services;
 
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.text.Normalizer;
+import java.util.regex.Pattern;
 import pt.estga.shared.enums.UserRole;
 import pt.estga.user.dtos.KeycloakIdentitySnapshot;
 import pt.estga.user.entities.User;
 
 import java.util.UUID;
+import java.time.Instant;
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
 public class KeycloakJitProvisioningService {
 
     private final UserService userService;
+    private static final Logger log = LoggerFactory.getLogger(KeycloakJitProvisioningService.class);
+    private static final int SUB_SUFFIX_LENGTH = 8;
+    private static final int MAX_USERNAME_LENGTH = 30;
+    private static final Pattern ALLOWED_USERNAME = Pattern.compile("[^a-zA-Z0-9._-]");
 
     @Transactional
     public User resolveOrProvision(KeycloakIdentitySnapshot snapshot) {
+        // Require Keycloak subject as the primary external lookup key
+        if (snapshot.sub() == null || snapshot.sub().isBlank()) {
+            log.warn("Keycloak snapshot missing sub claim; cannot resolve or provision user: {}", snapshot);
+            throw new IllegalArgumentException("Keycloak snapshot must contain a subject (sub)");
+        }
+
         return userService.findByKeycloakSub(snapshot.sub())
                 .map(existing -> syncSnapshot(existing, snapshot))
                 .orElseGet(() -> linkOrCreate(snapshot));
@@ -33,11 +49,19 @@ public class KeycloakJitProvisioningService {
     }
 
     private User linkExistingUser(User existing, KeycloakIdentitySnapshot snapshot) {
+        // Only link when the identity provider has asserted the email as verified
+        if (!snapshot.emailVerified()) {
+            throw new IllegalStateException("Cannot link account: email address is not verified by Keycloak");
+        }
+
         if (existing.getKeycloakSub() != null && !existing.getKeycloakSub().equals(snapshot.sub())) {
             throw new IllegalStateException("User already linked to another Keycloak subject");
         }
 
+        // Link external identity and persist only if something actually changed
         existing.setKeycloakSub(snapshot.sub());
+        log.info("Linking existing user id={} email={} to Keycloak sub={}", existing.getId(), existing.getEmail(), snapshot.sub());
+
         return syncSnapshot(existing, snapshot);
     }
 
@@ -53,32 +77,50 @@ public class KeycloakJitProvisioningService {
                 .role(UserRole.USER)
                 .build();
 
+        log.info("Creating new user username={} email={} keycloakSub={}", user.getUsername(), user.getEmail(), user.getKeycloakSub());
         return userService.create(user);
     }
 
     private User syncSnapshot(User user, KeycloakIdentitySnapshot snapshot) {
-        if (snapshot.preferredUsername() != null && !snapshot.preferredUsername().isBlank()) {
-            user.setUsername(snapshot.preferredUsername());
-        }
+        boolean changed = false;
 
-        if (snapshot.givenName() != null && !snapshot.givenName().isBlank()) {
-            user.setFirstName(snapshot.givenName());
-        }
-
-        if (snapshot.familyName() != null && !snapshot.familyName().isBlank()) {
-            user.setLastName(snapshot.familyName());
-        }
-
+        // Email and verification status: update only when different
         if (snapshot.email() != null) {
-            user.setEmail(snapshot.email());
-            user.setEmailVerified(snapshot.emailVerified());
+            if (!snapshot.email().equals(user.getEmail())) {
+                user.setEmail(snapshot.email());
+                changed = true;
+            }
+            if (snapshot.emailVerified() != user.isEmailVerified()) {
+                user.setEmailVerified(snapshot.emailVerified());
+                changed = true;
+            }
         }
 
-        return userService.update(user);
+        // Keycloak subject: ensure local DB stores the external lookup key; persist when changed
+        if (snapshot.sub() != null && !snapshot.sub().equals(user.getKeycloakSub())) {
+            user.setKeycloakSub(snapshot.sub());
+            changed = true;
+        }
+
+        // Do not overwrite local firstName/lastName to maintain local data ownership
+
+        // Update last login timestamp only when it's stale to avoid frequent DB writes
+        Instant now = Instant.now();
+        long minutesSinceLast = user.getLastLoginAt() == null ? Long.MAX_VALUE : Duration.between(user.getLastLoginAt(), now).toMinutes();
+        if (user.getLastLoginAt() == null || minutesSinceLast >= 5) {
+            user.setLastLoginAt(now);
+            changed = true;
+        }
+
+        if (changed) {
+            return userService.update(user);
+        }
+
+        return user;
     }
 
     private String resolveUsername(KeycloakIdentitySnapshot snapshot) {
-        // 1. Pick the best starting point
+        // 1. Pick readable base
         String base = snapshot.preferredUsername();
         if (base == null || base.isBlank()) {
             base = (snapshot.email() != null && snapshot.email().contains("@"))
@@ -86,14 +128,53 @@ public class KeycloakJitProvisioningService {
                     : "user";
         }
 
-        // 2. Sanitize: Remove non-alphanumeric characters (keep it clean)
-        base = base.replaceAll("[^a-zA-Z0-9]", "").toLowerCase();
+        // 2. Sanitize base to remove emojis and special characters
+        base = sanitizeUsernameBase(base);
 
-        // 3. Extract deterministic suffix from sub
-        // Using 8 chars gives 16^8 (~4.2 billion) possibilities, safe for collisions
+        // 3. Deterministic suffix from Keycloak sub (keep only alphanumeric characters)
         String sub = snapshot.sub() != null ? snapshot.sub() : UUID.randomUUID().toString();
-        String suffix = sub.substring(0, Math.min(sub.length(), 8));
+        String suffix = alphaNumericSuffixFromSub(sub);
 
-        return base + "_" + suffix;
+        String candidate = base + "_" + suffix;
+
+        // Ensure max length
+        if (candidate.length() > MAX_USERNAME_LENGTH) {
+            int keep = MAX_USERNAME_LENGTH - 1 - suffix.length(); // -1 for '_'
+            String truncatedBase = base.substring(0, Math.min(base.length(), keep));
+            candidate = truncatedBase + "_" + suffix;
+        }
+
+        return candidate.toLowerCase();
+    }
+
+    private String sanitizeUsernameBase(String input) {
+        if (input == null) return "user";
+
+        // Normalize unicode to separate diacritics, then remove them
+        String normalized = Normalizer.normalize(input, Normalizer.Form.NFKC);
+
+        // Remove characters not allowed in usernames (this also strips emojis)
+        String cleaned = ALLOWED_USERNAME.matcher(normalized).replaceAll("");
+
+        // Collapse consecutive dots/underscores/dashes
+        cleaned = cleaned.replaceAll("[._-]{2,}", "_");
+
+        // Trim and enforce minimum content
+        cleaned = cleaned.trim();
+        if (cleaned.isEmpty()) return "user";
+
+        // Truncate to reasonable length (leave space for suffix)
+        int maxBase = Math.max(1, MAX_USERNAME_LENGTH - 1 - SUB_SUFFIX_LENGTH);
+        if (cleaned.length() > maxBase) {
+            cleaned = cleaned.substring(0, maxBase);
+        }
+
+        return cleaned;
+    }
+
+    private String alphaNumericSuffixFromSub(String sub) {
+        // Assume sanitized Keycloak sub yields at least one alphanumeric character
+        String subAlpha = sub.replaceAll("[^A-Za-z0-9]", "");
+        return subAlpha.substring(0, Math.min(subAlpha.length(), SUB_SUFFIX_LENGTH));
     }
 }

--- a/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
+++ b/user/src/main/java/pt/estga/user/services/KeycloakJitProvisioningService.java
@@ -3,6 +3,8 @@ package pt.estga.user.services;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.text.Normalizer;
@@ -14,18 +16,21 @@ import pt.estga.user.entities.User;
 import java.util.UUID;
 import java.time.Instant;
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Service
 @RequiredArgsConstructor
 public class KeycloakJitProvisioningService {
 
     private final UserService userService;
+    private KeycloakJitProvisioningService self;
     private static final Logger log = LoggerFactory.getLogger(KeycloakJitProvisioningService.class);
     private static final int SUB_SUFFIX_LENGTH = 8;
     private static final int MAX_USERNAME_LENGTH = 30;
     private static final Pattern ALLOWED_USERNAME = Pattern.compile("[^a-zA-Z0-9._-]");
 
     @Transactional
+    @Cacheable(value = "user_provisioning", key = "#snapshot.sub()")
     public User resolveOrProvision(KeycloakIdentitySnapshot snapshot) {
         // Require Keycloak subject as the primary external lookup key
         if (snapshot.sub() == null || snapshot.sub().isBlank()) {
@@ -113,10 +118,27 @@ public class KeycloakJitProvisioningService {
         }
 
         if (changed) {
-            return userService.update(user);
+            User updated = userService.update(user);
+            // Evict cache via the proxied self reference so @CacheEvict takes effect
+            if (self != null) {
+                self.evictProvisioningCache(updated.getKeycloakSub());
+            }
+            return updated;
         }
 
         return user;
+    }
+
+    @CacheEvict(value = "user_provisioning", key = "#key")
+    // Separate method so Spring can apply the cache eviction advice
+    @SuppressWarnings("unused")
+    public void evictProvisioningCache(String key) {
+        // Intentionally left blank; annotation triggers eviction via Spring AOP.
+    }
+
+    @Autowired
+    public void setSelf(KeycloakJitProvisioningService self) {
+        this.self = self;
     }
 
     private String resolveUsername(KeycloakIdentitySnapshot snapshot) {

--- a/user/src/test/java/pt/estga/user/services/KeycloakJitProvisioningServiceTest.java
+++ b/user/src/test/java/pt/estga/user/services/KeycloakJitProvisioningServiceTest.java
@@ -3,18 +3,20 @@ package pt.estga.user.services;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import pt.estga.shared.enums.UserRole;
 import pt.estga.user.dtos.KeycloakIdentitySnapshot;
 import pt.estga.user.entities.User;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,229 +26,89 @@ class KeycloakJitProvisioningServiceTest {
     private UserService userService;
 
     @InjectMocks
-    private KeycloakJitProvisioningService jitProvisioningService;
+    private KeycloakJitProvisioningService service;
 
-    private User existingUser;
-    private KeycloakIdentitySnapshot newUserSnapshot;
-    private KeycloakIdentitySnapshot existingUserSnapshot;
+    @Captor
+    private ArgumentCaptor<User> userCaptor;
 
     @BeforeEach
     void setUp() {
-        existingUser = User.builder()
-                .id(1L)
-                .username("existing-user")
-                .email("existing@example.com")
-                .emailVerified(true)
-                .keycloakSub("existing-sub-123")
-                .enabled(true)
-                .role(UserRole.USER)
-                .build();
-
-        newUserSnapshot = new KeycloakIdentitySnapshot(
-                "new-sub-456",
-                "newuser",
-                "New",
-                "User",
-                "new@example.com",
-                true
-        );
-
-        existingUserSnapshot = new KeycloakIdentitySnapshot(
-                "existing-sub-123",
-                "existing-user",
-                "Existing",
-                "User",
-                "existing@example.com",
-                true
-        );
     }
 
     @Test
-    void resolveOrProvision_shouldReturnExistingUser_whenKeycloakSubExists() {
-        when(userService.findByKeycloakSub("existing-sub-123")).thenReturn(Optional.of(existingUser));
-        when(userService.update(any(User.class))).thenReturn(existingUser);
+    void resolveOrProvision_rejectsMissingSub() {
+        KeycloakIdentitySnapshot snapshot = new KeycloakIdentitySnapshot(null, "u", null, null, null, false);
 
-        User result = jitProvisioningService.resolveOrProvision(existingUserSnapshot);
-
-        assertNotNull(result);
-        assertEquals("existing-sub-123", result.getKeycloakSub());
-        assertEquals("existing@example.com", result.getEmail());
-        verify(userService).findByKeycloakSub("existing-sub-123");
-        verify(userService).update(existingUser);
-        verify(userService, never()).create(any(User.class));
+        assertThrows(IllegalArgumentException.class, () -> service.resolveOrProvision(snapshot));
     }
 
     @Test
-    void resolveOrProvision_shouldCreateNewUser_whenKeycloakSubNotFoundAndNoEmailMatch() {
-        when(userService.findByKeycloakSub("new-sub-456")).thenReturn(Optional.empty());
-        when(userService.findByEmail("new@example.com")).thenReturn(Optional.empty());
-        when(userService.existsByUsername(anyString())).thenReturn(false);
+    void resolveOrProvision_createsUser_withSanitizedUsernameAndSuffix() {
+        String sub = "550e8400-e29b-41d4-a716-446655440000";
+        KeycloakIdentitySnapshot snapshot = new KeycloakIdentitySnapshot(sub, "John😊.Doe", "John", "Doe", "john@example.com", true);
+
+        when(userService.findByKeycloakSub(sub)).thenReturn(Optional.empty());
+        when(userService.findByEmail("john@example.com")).thenReturn(Optional.empty());
         when(userService.create(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User result = jitProvisioningService.resolveOrProvision(newUserSnapshot);
+        service.resolveOrProvision(snapshot);
 
-        assertNotNull(result);
-        assertEquals("new-sub-456", result.getKeycloakSub());
-        assertEquals("new@example.com", result.getEmail());
-        assertEquals("newuser", result.getUsername());
-        assertEquals("New", result.getFirstName());
-        assertEquals("User", result.getLastName());
-        assertTrue(result.isEmailVerified());
-        assertEquals(UserRole.USER, result.getRole());
-        assertTrue(result.isEnabled());
+        verify(userService).create(userCaptor.capture());
+        User passed = userCaptor.getValue();
 
-        verify(userService).findByKeycloakSub("new-sub-456");
-        verify(userService).findByEmail("new@example.com");
-        verify(userService).create(any(User.class));
+        assertEquals("john.doe_550e8400", passed.getUsername());
+        assertEquals(sub, passed.getKeycloakSub());
+        assertEquals("john@example.com", passed.getEmail());
     }
 
     @Test
-    void resolveOrProvision_shouldLinkExistingUserByEmail_whenVerified() {
-        User userWithoutKeycloak = User.builder()
-                .id(3L)
-                .username("legacy-user")
-                .email("new@example.com")
-                .emailVerified(true)
-                .keycloakSub(null)
-                .enabled(true)
-                .role(UserRole.USER)
-                .build();
-
-        when(userService.findByKeycloakSub("new-sub-456")).thenReturn(Optional.empty());
-        when(userService.findByEmail("new@example.com")).thenReturn(Optional.of(userWithoutKeycloak));
-        when(userService.update(any(User.class))).thenReturn(userWithoutKeycloak);
-
-        User result = jitProvisioningService.resolveOrProvision(newUserSnapshot);
-
-        assertNotNull(result);
-        assertEquals("new-sub-456", result.getKeycloakSub());
-        assertEquals("new@example.com", result.getEmail());
-
-        verify(userService).findByKeycloakSub("new-sub-456");
-        verify(userService).findByEmail("new@example.com");
-        verify(userService).update(userWithoutKeycloak);
-        verify(userService, never()).create(any(User.class));
-    }
-
-    @Test
-    void resolveOrProvision_shouldThrowException_whenEmailAlreadyLinkedToDifferentKeycloakSub() {
-        User userWithDifferentSub = User.builder()
-                .id(4L)
-                .username("other-user")
-                .email("new@example.com")
-                .emailVerified(true)
-                .keycloakSub("other-sub-789")
-                .enabled(true)
-                .role(UserRole.USER)
-                .build();
-
-        when(userService.findByKeycloakSub("new-sub-456")).thenReturn(Optional.empty());
-        when(userService.findByEmail("new@example.com")).thenReturn(Optional.of(userWithDifferentSub));
-
-        assertThrows(IllegalStateException.class, () -> jitProvisioningService.resolveOrProvision(newUserSnapshot));
-
-        verify(userService).findByKeycloakSub("new-sub-456");
-        verify(userService).findByEmail("new@example.com");
-        verify(userService, never()).update(any(User.class));
-        verify(userService, never()).create(any(User.class));
-    }
-
-    @Test
-    void resolveOrProvision_shouldCreateUser_whenEmailUnverified() {
-        KeycloakIdentitySnapshot unverifiedSnapshot = new KeycloakIdentitySnapshot(
-                "unverified-sub",
-                "unverified-user",
-                "Unverified",
-                "User",
-                "unverified@example.com",
-                false
-        );
-
-        User newUser = User.builder()
-                .id(5L)
-                .username("unverified-user")
-                .email("unverified@example.com")
+    void syncSnapshot_updatesOnlyWhenChanged_andUpdatesLastLoginAfterThreshold() {
+        String sub = "550e8400-e29b-41d4-a716-446655440000";
+        User existing = User.builder()
+                .id(1L)
+                .username("john.doe_550e8400")
+                .email("john@example.com")
                 .emailVerified(false)
-                .keycloakSub("unverified-sub")
-                .enabled(true)
-                .role(UserRole.USER)
+                .keycloakSub(sub)
                 .build();
 
-        when(userService.findByKeycloakSub("unverified-sub")).thenReturn(Optional.empty());
-        when(userService.existsByUsername(anyString())).thenReturn(false);
-        when(userService.create(any(User.class))).thenReturn(newUser);
+        // last login 10 minutes ago => should be updated
+        existing.setLastLoginAt(Instant.now().minus(10, ChronoUnit.MINUTES));
 
-        User result = jitProvisioningService.resolveOrProvision(unverifiedSnapshot);
+        KeycloakIdentitySnapshot snapshot = new KeycloakIdentitySnapshot(sub, null, null, null, "john@example.com", true);
 
-        assertNotNull(result);
-        assertEquals("unverified-sub", result.getKeycloakSub());
-        assertFalse(result.isEmailVerified());
-
-        verify(userService).findByKeycloakSub("unverified-sub");
-        verify(userService, never()).findByEmail(anyString());
-        verify(userService).create(any(User.class));
-    }
-
-    @Test
-    void resolveOrProvision_shouldSyncSnapshotFields_whenUserExists() {
-        KeycloakIdentitySnapshot updatedSnapshot = new KeycloakIdentitySnapshot(
-                "existing-sub-123",
-                "updated-username",
-                "Updated",
-                "Name",
-                "updated@example.com",
-                true
-        );
-
-        when(userService.findByKeycloakSub("existing-sub-123")).thenReturn(Optional.of(existingUser));
+        when(userService.findByKeycloakSub(sub)).thenReturn(Optional.of(existing));
         when(userService.update(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
-        User result = jitProvisioningService.resolveOrProvision(updatedSnapshot);
+        User result = service.resolveOrProvision(snapshot);
 
-        assertNotNull(result);
-        assertEquals("updated-username", result.getUsername());
-        assertEquals("Updated", result.getFirstName());
-        assertEquals("Name", result.getLastName());
-        assertEquals("updated@example.com", result.getEmail());
-        assertTrue(result.isEmailVerified());
+        verify(userService, times(1)).update(userCaptor.capture());
+        User updated = userCaptor.getValue();
 
-        verify(userService).update(existingUser);
+        assertTrue(updated.isEmailVerified());
+        assertNotNull(updated.getLastLoginAt());
+        assertEquals(result.getLastLoginAt(), updated.getLastLoginAt());
     }
 
     @Test
-    void resolveOrProvision_shouldGenerateUniqueUsername_whenPreferredUsernameExists() {
-        KeycloakIdentitySnapshot duplicateUsernameSnapshot = new KeycloakIdentitySnapshot(
-                "duplicate-sub",
-                "existing-user",
-                "Dup",
-                "User",
-                "duplicate@example.com",
-                true
-        );
+    void linkExistingUser_throwsWhenAlreadyLinkedToDifferentSub() {
+        String existingSub = "existing-sub-123";
+        String newSub = "550e8400-e29b-41d4-a716-446655440000";
 
-        User newUser = User.builder()
-                .id(7L)
-                .username("existing-user1")
-                .email("duplicate@example.com")
-                .emailVerified(true)
-                .keycloakSub("duplicate-sub")
-                .enabled(true)
-                .role(UserRole.USER)
+        User existing = User.builder()
+                .id(2L)
+                .email("jane@example.com")
+                .keycloakSub(existingSub)
                 .build();
 
-        when(userService.findByKeycloakSub("duplicate-sub")).thenReturn(Optional.empty());
-        when(userService.findByEmail("duplicate@example.com")).thenReturn(Optional.empty());
-        when(userService.existsByUsername("existing-user")).thenReturn(true);
-        when(userService.existsByUsername("existing-user1")).thenReturn(false);
-        when(userService.create(any(User.class))).thenReturn(newUser);
+        KeycloakIdentitySnapshot snapshot = new KeycloakIdentitySnapshot(newSub, null, null, null, "jane@example.com", true);
 
-        User result = jitProvisioningService.resolveOrProvision(duplicateUsernameSnapshot);
+        when(userService.findByKeycloakSub(newSub)).thenReturn(Optional.empty());
+        when(userService.findByEmail("jane@example.com")).thenReturn(Optional.of(existing));
 
-        assertNotNull(result);
-        assertEquals("existing-user1", result.getUsername());
+        assertThrows(IllegalStateException.class, () -> service.resolveOrProvision(snapshot));
 
-        verify(userService).existsByUsername("existing-user");
-        verify(userService).existsByUsername("existing-user1");
-        verify(userService).create(any(User.class));
+        verify(userService, never()).create(any());
+        verify(userService, never()).update(any());
     }
 }


### PR DESCRIPTION
This pull request introduces several significant improvements and refactors to user provisioning, authentication, and user entity management, especially around Keycloak integration and user profile handling. The changes focus on stricter user account checks, improved cache management, a more robust and deterministic username generation for JIT provisioning, and simplification of user profile photo handling.

**Keycloak JIT Provisioning and Authentication Improvements:**

* Added a critical check to block authentication for users who are disabled or have locked accounts in the local database during JWT conversion, preventing inactive users from logging in.
* Enhanced the `KeycloakJitProvisioningService` with:
  - Caching for user provisioning using `@Cacheable` and explicit cache eviction to improve performance and consistency. [[1]](diffhunk://#diff-e2e1ad6f5473832276aa360e763bd5fd7b4e341ceed7ad77ad054dd30518d61eR4-R40) [[2]](diffhunk://#diff-e2e1ad6f5473832276aa360e763bd5fd7b4e341ceed7ad77ad054dd30518d61eR85-R197)
  - Deterministic and sanitized username generation for new users, ensuring usernames are readable, unique, and free from special characters/emojis.
  - Improved account linking logic to require verified emails and detailed logging for traceability.
  - Efficient user synchronization that only updates fields when necessary, including last login timestamp management.

**User Entity and Profile Refactoring:**

* Updated the `User` entity to:
  - Implement `Serializable` for better compatibility and caching support.
  - Remove the direct `MediaFile photo` field, decoupling user profiles from photo storage.
  - Add a `lastLoginAt` field for tracking user activity.
  - Refactor `equals` and `hashCode` to prioritize `keycloakSub` as the identity key, improving consistency across external identity links.
  - Add detailed documentation for the `keycloakSub` field.

**User Profile and Controller Simplification:**

* Simplified the account controller by:
  - Removing endpoints and logic related to profile photo upload and management, reflecting the decoupling from `MediaFile`.
  - Cleaning up unused imports and dependencies. [[1]](diffhunk://#diff-afbef61d9a0882f046117ede0aa69842b477cf41b00625ba7b25c2937ed2d755L12-L18) [[2]](diffhunk://#diff-afbef61d9a0882f046117ede0aa69842b477cf41b00625ba7b25c2937ed2d755L27-L28)
* Updated DTOs and mappers to match the new user profile structure, removing photo-related mappings. [[1]](diffhunk://#diff-1c031751024f0f25b203b29eb02828c5e16f672dbee2234938e1a53a0a06b733L14-L16) [[2]](diffhunk://#diff-2feeff06f9d319ba16f946e9b43aa660e353e9366cde3174aee14cfd7dda3720L16-L22)

**Cache Configuration:**

* Updated cache configuration to support multiple cache names, including a new `user_provisioning` cache for JIT provisioning, and removed unnecessary options for simpler, more maintainable cache management.

**Testing Enhancements:**

* Improved test setup for `KeycloakJitProvisioningService` by adding necessary imports and capturing arguments for more thorough testing.