### PR TITLE
Feature/base entity

### DIFF
--- a/file/src/main/java/pt/estga/file/entities/MediaFile.java
+++ b/file/src/main/java/pt/estga/file/entities/MediaFile.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import pt.estga.file.enums.MediaStatus;
 import pt.estga.file.enums.StorageProvider;
-import pt.estga.shared.audit.CreationAuditedEntity;
+import pt.estga.shared.entities.CreationAuditedEntity;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/intake/pom.xml
+++ b/intake/pom.xml
@@ -26,11 +26,6 @@
         </dependency>
         <dependency>
             <groupId>pt.estga</groupId>
-            <artifactId>vision</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>pt.estga</groupId>
             <artifactId>shared</artifactId>
             <version>0.0.1-SNAPSHOT</version>
         </dependency>

--- a/intake/src/main/java/pt/estga/intake/entities/MarkEvidenceSubmission.java
+++ b/intake/src/main/java/pt/estga/intake/entities/MarkEvidenceSubmission.java
@@ -26,14 +26,6 @@ public class MarkEvidenceSubmission {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String userNotes;
-
-    @Enumerated(EnumType.STRING)
-    private SubmissionSource submissionSource;
-
-    @Enumerated(EnumType.STRING)
-    private SubmissionStatus status;
-
     @OneToOne(fetch = FetchType.LAZY)
     private MediaFile originalMediaFile;
 
@@ -42,6 +34,14 @@ public class MarkEvidenceSubmission {
 
     private Double latitude;
     private Double longitude;
+
+    private String userNotes;
+
+    @Enumerated(EnumType.STRING)
+    private SubmissionSource submissionSource;
+
+    @Enumerated(EnumType.STRING)
+    private SubmissionStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User submittedBy;

--- a/intake/src/main/java/pt/estga/intake/enums/SubmissionStatus.java
+++ b/intake/src/main/java/pt/estga/intake/enums/SubmissionStatus.java
@@ -1,8 +1,8 @@
 package pt.estga.intake.enums;
 
 public enum SubmissionStatus {
-    SUBMITTED,
-    UNDER_REVIEW,
-    MANUALLY_ACCEPTED,
-    MANUALLY_REJECTED
+    PENDING_ANALYSIS,
+    ENRICHED,
+    ACCEPTED,
+    REJECTED
 }

--- a/intake/src/main/java/pt/estga/intake/listeners/MarkEvidenceSubmittedListener.java
+++ b/intake/src/main/java/pt/estga/intake/listeners/MarkEvidenceSubmittedListener.java
@@ -1,0 +1,27 @@
+package pt.estga.intake.listeners;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import pt.estga.intake.events.MarkEvidenceSubmittedEvent;
+import pt.estga.intake.services.EnrichmentService;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MarkEvidenceSubmittedListener {
+
+    private final EnrichmentService enrichmentService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void enrichMarkEvidence(MarkEvidenceSubmittedEvent event) {
+        Long submissionId = event.getSubmissionId();
+        log.info("Async detection processing for submission ID: {}", submissionId);
+
+        enrichmentService.enrichSubmission(submissionId);
+    }
+}

--- a/intake/src/main/java/pt/estga/intake/services/EnrichmentService.java
+++ b/intake/src/main/java/pt/estga/intake/services/EnrichmentService.java
@@ -1,37 +1,39 @@
-package pt.estga.intake.listeners;
+package pt.estga.intake.services;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import pt.estga.file.application.MediaService;
+import pt.estga.intake.repositories.MarkEvidenceSubmissionRepository;
 import pt.estga.vision.DetectionResult;
 import pt.estga.vision.VisionClient;
-import pt.estga.file.application.MediaService;
-import pt.estga.intake.events.MarkEvidenceSubmittedEvent;
-import pt.estga.intake.repositories.MarkEvidenceSubmissionRepository;
 
 import java.io.InputStream;
 
-@Component
+/**
+ * Service responsible for enriching mark evidence submissions by running
+ * vision detection and persisting any produced embeddings.
+ */
+@Service
 @RequiredArgsConstructor
 @Slf4j
-public class SubmissionEnrichmentListener {
+public class EnrichmentService {
 
     private final MarkEvidenceSubmissionRepository markEvidenceSubmissionRepository;
     private final VisionClient visionClient;
     private final MediaService mediaService;
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    /**
+     * Enriches the submission identified by the provided id. This method runs
+     * in a new transaction so it can safely execute after the origin transaction
+     * has committed.
+     *
+     * @param submissionId id of the submission to enrich
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void handleMarkEvidenceSubmitted(MarkEvidenceSubmittedEvent event) {
-        Long submissionId = event.getSubmissionId();
-        log.info("Async detection processing for submission ID: {}", submissionId);
-
+    public void enrichSubmission(Long submissionId) {
         markEvidenceSubmissionRepository.findById(submissionId).ifPresentOrElse(submission -> {
             if (submission.getOriginalMediaFile() == null) {
                 log.info("Submission ID {} has no original media file. Skipping enrichment.", submissionId);
@@ -53,3 +55,4 @@ public class SubmissionEnrichmentListener {
         }, () -> log.warn("Submitted submission with ID {} not found during enrichment", submissionId));
     }
 }
+

--- a/intake/src/main/java/pt/estga/intake/services/MarkEvidenceSubmissionService.java
+++ b/intake/src/main/java/pt/estga/intake/services/MarkEvidenceSubmissionService.java
@@ -55,7 +55,7 @@ public class MarkEvidenceSubmissionService {
         // Preserve submittedBy and submissionSource that may already be present on the submission
 
         // Mark as submitted and persist
-        submission.setStatus(SubmissionStatus.SUBMITTED);
+        submission.setStatus(SubmissionStatus.PENDING_ANALYSIS);
         MarkEvidenceSubmission saved = submissionRepository.save(submission);
 
         // Publish event after transaction commit

--- a/mark/src/main/java/pt/estga/mark/entities/Mark.java
+++ b/mark/src/main/java/pt/estga/mark/entities/Mark.java
@@ -3,7 +3,7 @@ package pt.estga.mark.entities;
 import jakarta.persistence.*;
 import lombok.*;
 import pt.estga.file.entities.MediaFile;
-import pt.estga.shared.entities.AuditedEntity;
+import pt.estga.shared.entities.BaseEntity;
 
 import java.util.HashSet;
 import java.util.List;
@@ -15,7 +15,7 @@ import java.util.Set;
 @Getter
 @Setter
 @Builder
-public class Mark extends AuditedEntity {
+public class Mark extends BaseEntity {
 
     @Id
     @GeneratedValue
@@ -43,6 +43,4 @@ public class Mark extends AuditedEntity {
     @OneToMany(mappedBy = "mark")
     private List<MarkOccurrence> occurrences;
 
-    @Builder.Default
-    private Boolean active = true;
 }

--- a/mark/src/main/java/pt/estga/mark/entities/Mark.java
+++ b/mark/src/main/java/pt/estga/mark/entities/Mark.java
@@ -3,7 +3,7 @@ package pt.estga.mark.entities;
 import jakarta.persistence.*;
 import lombok.*;
 import pt.estga.file.entities.MediaFile;
-import pt.estga.shared.audit.AuditedEntity;
+import pt.estga.shared.entities.AuditedEntity;
 
 import java.util.HashSet;
 import java.util.List;

--- a/mark/src/main/java/pt/estga/mark/entities/MarkCategory.java
+++ b/mark/src/main/java/pt/estga/mark/entities/MarkCategory.java
@@ -2,6 +2,7 @@ package pt.estga.mark.entities;
 
 import jakarta.persistence.*;
 import lombok.*;
+import pt.estga.shared.entities.BaseEntity;
 
 import java.util.List;
 
@@ -11,7 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-public class MarkCategory {
+public class MarkCategory extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/mark/src/main/java/pt/estga/mark/entities/MarkEvidence.java
+++ b/mark/src/main/java/pt/estga/mark/entities/MarkEvidence.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 import pt.estga.file.entities.MediaFile;
-import pt.estga.shared.entities.AuditedEntity;
+import pt.estga.shared.entities.BaseEntity;
 
 import java.util.UUID;
 
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Getter
 @Setter
 @Builder
-public class MarkEvidence extends AuditedEntity {
+public class MarkEvidence extends BaseEntity {
 
     @Id
     @GeneratedValue

--- a/mark/src/main/java/pt/estga/mark/entities/MarkEvidence.java
+++ b/mark/src/main/java/pt/estga/mark/entities/MarkEvidence.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.UuidGenerator;
 import pt.estga.file.entities.MediaFile;
-import pt.estga.shared.audit.AuditedEntity;
+import pt.estga.shared.entities.AuditedEntity;
 
 import java.util.UUID;
 

--- a/mark/src/main/java/pt/estga/mark/entities/MarkOccurrence.java
+++ b/mark/src/main/java/pt/estga/mark/entities/MarkOccurrence.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import pt.estga.file.entities.MediaFile;
 import pt.estga.monument.Monument;
-import pt.estga.shared.entities.AuditedEntity;
+import pt.estga.shared.entities.BaseEntity;
 import pt.estga.user.entities.User;
 
 import java.time.Instant;
@@ -16,7 +16,7 @@ import java.util.List;
 @Getter
 @Setter
 @Builder
-public class MarkOccurrence extends AuditedEntity {
+public class MarkOccurrence extends BaseEntity {
 
     @Id
     @GeneratedValue
@@ -41,9 +41,6 @@ public class MarkOccurrence extends AuditedEntity {
     private User author;
 
     private Instant publishedAt;
-
-    @Builder.Default
-    private Boolean active = true;
 
     @PrePersist
     public void prePersist() {

--- a/mark/src/main/java/pt/estga/mark/entities/MarkOccurrence.java
+++ b/mark/src/main/java/pt/estga/mark/entities/MarkOccurrence.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import pt.estga.file.entities.MediaFile;
 import pt.estga.monument.Monument;
-import pt.estga.shared.audit.AuditedEntity;
+import pt.estga.shared.entities.AuditedEntity;
 import pt.estga.user.entities.User;
 
 import java.time.Instant;

--- a/mark/src/main/java/pt/estga/mark/repositories/MarkCategoryRepository.java
+++ b/mark/src/main/java/pt/estga/mark/repositories/MarkCategoryRepository.java
@@ -1,7 +1,7 @@
 package pt.estga.mark.repositories;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import pt.estga.mark.entities.MarkCategory;
+import pt.estga.shared.repositories.BaseRepository;
 
-public interface MarkCategoryRepository extends JpaRepository<MarkCategory, Long> {
+public interface MarkCategoryRepository extends BaseRepository<MarkCategory, Long> {
 }

--- a/mark/src/main/java/pt/estga/mark/repositories/MarkEvidenceRepository.java
+++ b/mark/src/main/java/pt/estga/mark/repositories/MarkEvidenceRepository.java
@@ -1,9 +1,9 @@
 package pt.estga.mark.repositories;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import pt.estga.mark.entities.MarkEvidence;
+import pt.estga.shared.repositories.BaseRepository;
 
 import java.util.UUID;
 
-public interface MarkEvidenceRepository extends JpaRepository<MarkEvidence, UUID> {
+public interface MarkEvidenceRepository extends BaseRepository<MarkEvidence, UUID> {
 }

--- a/mark/src/main/java/pt/estga/mark/repositories/MarkOccurrenceRepository.java
+++ b/mark/src/main/java/pt/estga/mark/repositories/MarkOccurrenceRepository.java
@@ -3,22 +3,14 @@ package pt.estga.mark.repositories;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import pt.estga.mark.entities.MarkOccurrence;
-
-import java.util.Optional;
+import pt.estga.shared.repositories.BaseRepository;
 
 @Repository
-public interface MarkOccurrenceRepository extends JpaRepository<MarkOccurrence, Long> {
-
-    @EntityGraph(attributePaths = {"monument", "mark", "author"})
-    Page<MarkOccurrence> findByActiveIsTrue(Pageable pageable);
+public interface MarkOccurrenceRepository extends BaseRepository<MarkOccurrence, Long> {
 
     @Override
     @EntityGraph(attributePaths = {"monument", "mark", "author"})
     Page<MarkOccurrence> findAll(Pageable pageable);
-
-    @EntityGraph(attributePaths = {"monument.district", "monument.parish", "monument.municipality", "mark", "author"})
-    Optional<MarkOccurrence> findById(Long id);
 }

--- a/mark/src/main/java/pt/estga/mark/repositories/MarkRepository.java
+++ b/mark/src/main/java/pt/estga/mark/repositories/MarkRepository.java
@@ -1,9 +1,9 @@
 package pt.estga.mark.repositories;
 
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import pt.estga.mark.entities.Mark;
+import pt.estga.shared.repositories.BaseRepository;
 
 @Repository
-public interface MarkRepository extends JpaRepository<Mark, Long> {
+public interface MarkRepository extends BaseRepository<Mark, Long> {
 }

--- a/mark/src/main/java/pt/estga/mark/services/MarkOccurrenceQueryService.java
+++ b/mark/src/main/java/pt/estga/mark/services/MarkOccurrenceQueryService.java
@@ -1,8 +1,6 @@
 package pt.estga.mark.services;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pt.estga.mark.entities.MarkOccurrence;
@@ -16,10 +14,6 @@ import java.util.Optional;
 public class MarkOccurrenceQueryService {
 
     private final MarkOccurrenceRepository repository;
-
-    public Page<MarkOccurrence> findAll(Pageable pageable) {
-        return repository.findByActiveIsTrue(pageable);
-    }
 
     public Optional<MarkOccurrence> findById(Long id) {
         return repository.findById(id);

--- a/monument/src/main/java/pt/estga/monument/Monument.java
+++ b/monument/src/main/java/pt/estga/monument/Monument.java
@@ -6,8 +6,8 @@ import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import pt.estga.shared.entities.BaseEntity;
 import pt.estga.territory.entities.AdministrativeDivision;
-import pt.estga.shared.entities.AuditedEntity;
 
 @Entity
 @NoArgsConstructor
@@ -15,7 +15,7 @@ import pt.estga.shared.entities.AuditedEntity;
 @Getter
 @Setter
 @Builder
-public class Monument extends AuditedEntity {
+public class Monument extends BaseEntity {
 
     @Id
     @GeneratedValue
@@ -45,9 +45,6 @@ public class Monument extends AuditedEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private AdministrativeDivision district;
-
-    @Builder.Default
-    private Boolean active = true;
 
     @PrePersist
     @PreUpdate

--- a/monument/src/main/java/pt/estga/monument/Monument.java
+++ b/monument/src/main/java/pt/estga/monument/Monument.java
@@ -27,6 +27,7 @@ public class Monument extends BaseEntity {
     private String name;
     private String protectionTitle;
     private String description;
+    // Todo: delete latitude and longitude
     private Double latitude;
     private Double longitude;
     private String website;
@@ -37,6 +38,7 @@ public class Monument extends BaseEntity {
     @Column(columnDefinition = "geometry(Point, 4326)")
     private Point location;
 
+    // Todo: leave only 1 AD (parish -> division)
     @ManyToOne(fetch = FetchType.EAGER)
     private AdministrativeDivision parish;
 

--- a/monument/src/main/java/pt/estga/monument/Monument.java
+++ b/monument/src/main/java/pt/estga/monument/Monument.java
@@ -7,7 +7,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
 import pt.estga.territory.entities.AdministrativeDivision;
-import pt.estga.shared.audit.AuditedEntity;
+import pt.estga.shared.entities.AuditedEntity;
 
 @Entity
 @NoArgsConstructor

--- a/monument/src/main/java/pt/estga/monument/MonumentRepository.java
+++ b/monument/src/main/java/pt/estga/monument/MonumentRepository.java
@@ -14,9 +14,6 @@ import java.util.Optional;
 public interface MonumentRepository extends BaseRepository<Monument, Long> {
 
     @EntityGraph(attributePaths = {"district", "parish", "municipality"})
-    Optional<Monument> findById(Long id);
-
-    @EntityGraph(attributePaths = {"district", "parish", "municipality"})
     Page<Monument> findByDistrictIdOrMunicipalityIdOrParishIdAndActive(Long districtId, Long municipalityId, Long parishId, Pageable pageable, boolean active);
 
     default Page<Monument> findByDivisionId(Long divisionId, Pageable pageable, boolean active) {

--- a/monument/src/main/java/pt/estga/monument/MonumentRepository.java
+++ b/monument/src/main/java/pt/estga/monument/MonumentRepository.java
@@ -3,27 +3,27 @@ package pt.estga.monument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import pt.estga.shared.enums.EntityStatus;
 import pt.estga.shared.repositories.BaseRepository;
 
 import java.util.Optional;
 
 @Repository
-public interface MonumentRepository extends BaseRepository<Monument, Long> {
+public interface MonumentRepository extends BaseRepository<Monument, Long>, JpaSpecificationExecutor<Monument> {
 
     @EntityGraph(attributePaths = {"district", "parish", "municipality"})
-    Page<Monument> findByDistrictIdOrMunicipalityIdOrParishIdAndActive(Long districtId, Long municipalityId, Long parishId, Pageable pageable, boolean active);
+    Page<Monument> findByDistrictIdOrMunicipalityIdOrParishIdAndStatus(Long districtId, Long municipalityId, Long parishId, Pageable pageable, EntityStatus status);
 
-    default Page<Monument> findByDivisionId(Long divisionId, Pageable pageable, boolean active) {
-        return findByDistrictIdOrMunicipalityIdOrParishIdAndActive(divisionId, divisionId, divisionId, pageable, active);
+    default Page<Monument> findByDivisionId(Long divisionId, Pageable pageable) {
+        return findByDistrictIdOrMunicipalityIdOrParishIdAndStatus(divisionId, divisionId, divisionId, pageable, EntityStatus.ACTIVE);
     }
 
     Optional<Monument> findByExternalId(String externalId);
 
-    Page<Monument> findByNameContainingIgnoreCaseAndActive(String name, Pageable pageable, boolean active);
-
-    @Query(value = "SELECT * FROM monument m WHERE ST_Within(m.location, ST_GeomFromGeoJSON(:geoJson)) AND m.active = :active", nativeQuery = true)
-    Page<Monument> findByPolygon(@Param("geoJson") String geoJson, Pageable pageable, @Param("active") boolean active);
+    @Query(value = "SELECT * FROM monument m WHERE ST_Within(m.location, ST_GeomFromGeoJSON(:geoJson))", nativeQuery = true)
+    Page<Monument> findByPolygon(@Param("geoJson") String geoJson, Pageable pageable);
 }

--- a/monument/src/main/java/pt/estga/monument/MonumentRepository.java
+++ b/monument/src/main/java/pt/estga/monument/MonumentRepository.java
@@ -3,15 +3,15 @@ package pt.estga.monument;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
-import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import pt.estga.shared.repositories.BaseRepository;
 
 import java.util.Optional;
 
 @Repository
-public interface MonumentRepository extends JpaRepository<Monument, Long> {
+public interface MonumentRepository extends BaseRepository<Monument, Long> {
 
     @EntityGraph(attributePaths = {"district", "parish", "municipality"})
     Optional<Monument> findById(Long id);

--- a/monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java
+++ b/monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java
@@ -1,15 +1,12 @@
 package pt.estga.monument.controllers;
 
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import pt.estga.monument.Monument;
 import pt.estga.monument.MonumentMapper;
@@ -32,10 +29,10 @@ public class MonumentAdminController {
     private final MonumentQueryService queryService;
     private final MonumentMapper mapper;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PostMapping
     public ResponseEntity<MonumentDto> createMonument(
-            @RequestPart("data") @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid MonumentRequestDto monumentDto,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @Parameter(description = "Monument form data", required = true)
+            @Valid @ModelAttribute MonumentRequestDto monumentDto
     ) {
         Monument monument = mapper.toEntity(monumentDto);
 
@@ -51,11 +48,11 @@ public class MonumentAdminController {
         return ResponseEntity.created(location).body(response);
     }
 
-    @PutMapping(value = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping(value = "/{id}")
     public ResponseEntity<MonumentDto> updateMonument(
             @PathVariable Long id,
-            @RequestPart("data") @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) @Valid MonumentRequestDto monumentDto,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @Parameter(description = "Monument form data", required = true)
+            @Valid @ModelAttribute MonumentRequestDto monumentDto
     ) {
         Monument existingMonument = service.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Monument not found"));
@@ -72,22 +69,5 @@ public class MonumentAdminController {
     ) {
         service.deleteById(id);
         return ResponseEntity.noContent().build();
-    }
-
-    @PostMapping(value = "/{id}/photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<MonumentDto> uploadPhoto(
-            @PathVariable Long id,
-            @RequestParam("file") MultipartFile file
-    ) {
-        if (file.isEmpty()) {
-            return ResponseEntity.badRequest().build();
-        }
-
-        Monument monument = service.findById(id)
-                .orElseThrow(() -> new ResourceNotFoundException("Monument not found"));
-
-        Monument updatedMonument = service.update(monument);
-
-        return ResponseEntity.ok(mapper.toResponseDto(updatedMonument));
     }
 }

--- a/monument/src/main/java/pt/estga/monument/controllers/MonumentController.java
+++ b/monument/src/main/java/pt/estga/monument/controllers/MonumentController.java
@@ -12,6 +12,7 @@ import pt.estga.monument.MonumentMapper;
 import pt.estga.monument.services.MonumentQueryService;
 import pt.estga.monument.dots.MonumentDto;
 import pt.estga.monument.dots.MonumentListDto;
+import pt.estga.sharedweb.models.PagedRequest;
 
 @RestController
 @RequestMapping("/api/v1/public/monuments")
@@ -32,13 +33,11 @@ public class MonumentController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @GetMapping("/search")
+    @PostMapping("/search")
     public ResponseEntity<Page<MonumentListDto>> searchMonuments(
-            @RequestParam String query,
-            @PageableDefault(size = 9, sort = "name") Pageable pageable
+            @RequestBody PagedRequest request
     ) {
-        // Todo: implement proper search
-        return ResponseEntity.ok(service.searchByName(query, pageable).map(mapper::toListDto));
+        return ResponseEntity.ok(service.search(request));
     }
 
     @PostMapping(value = "/search/polygon", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/monument/src/main/java/pt/estga/monument/controllers/MonumentController.java
+++ b/monument/src/main/java/pt/estga/monument/controllers/MonumentController.java
@@ -37,6 +37,7 @@ public class MonumentController {
             @RequestParam String query,
             @PageableDefault(size = 9, sort = "name") Pageable pageable
     ) {
+        // Todo: implement proper search
         return ResponseEntity.ok(service.searchByName(query, pageable).map(mapper::toListDto));
     }
 

--- a/monument/src/main/java/pt/estga/monument/services/MonumentQueryService.java
+++ b/monument/src/main/java/pt/estga/monument/services/MonumentQueryService.java
@@ -7,6 +7,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pt.estga.monument.Monument;
 import pt.estga.monument.MonumentRepository;
+import pt.estga.monument.dots.MonumentListDto;
+import pt.estga.monument.MonumentMapper;
+import pt.estga.sharedweb.filtering.QueryProcessor;
+import pt.estga.sharedweb.models.PagedRequest;
+import pt.estga.sharedweb.models.QueryResult;
 
 import java.util.Optional;
 
@@ -16,20 +21,29 @@ import java.util.Optional;
 public class MonumentQueryService {
 
     private final MonumentRepository repository;
+    private final QueryProcessor<Monument> queryProcessor;
+    private final MonumentMapper mapper;
 
     public Optional<Monument> findById(Long id) {
         return repository.findById(id);
     }
 
-    public Page<Monument> searchByName(String query, Pageable pageable) {
-        return repository.findByNameContainingIgnoreCaseAndActive(query, pageable, true);
+    public Page<MonumentListDto> search(PagedRequest request) {
+        QueryResult<Monument> result = queryProcessor.process(request);
+
+        Page<Monument> monuments = repository.findAll(
+                result.specification(),
+                result.pageable()
+        );
+
+        return monuments.map(mapper::toListDto);
     }
 
     public Page<Monument> findByPolygon(String geoJson, Pageable pageable) {
-        return repository.findByPolygon(geoJson, pageable, true);
+        return repository.findByPolygon(geoJson, pageable);
     }
 
     public Page<Monument> findByDivisionId(Long id, Pageable pageable) {
-        return repository.findByDivisionId(id, pageable, true);
+        return repository.findByDivisionId(id, pageable);
     }
 }

--- a/processing/pom.xml
+++ b/processing/pom.xml
@@ -17,4 +17,22 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>pt.estga</groupId>
+            <artifactId>intake</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>pt.estga</groupId>
+            <artifactId>vision</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>pt.estga</groupId>
+            <artifactId>shared</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/processing/src/main/java/pt/estga/processing/listeners/MarkEvidenceSubmittedListener.java
+++ b/processing/src/main/java/pt/estga/processing/listeners/MarkEvidenceSubmittedListener.java
@@ -1,4 +1,4 @@
-package pt.estga.intake.listeners;
+package pt.estga.processing.listeners;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import pt.estga.intake.events.MarkEvidenceSubmittedEvent;
-import pt.estga.intake.services.EnrichmentService;
+import pt.estga.processing.services.EnrichmentService;
 
 @Component
 @RequiredArgsConstructor

--- a/processing/src/main/java/pt/estga/processing/services/EnrichmentService.java
+++ b/processing/src/main/java/pt/estga/processing/services/EnrichmentService.java
@@ -1,4 +1,4 @@
-package pt.estga.intake.services;
+package pt.estga.processing.services;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/report/src/main/java/pt/estga/report/entities/Report.java
+++ b/report/src/main/java/pt/estga/report/entities/Report.java
@@ -3,7 +3,7 @@ package pt.estga.report.entities;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import pt.estga.shared.audit.CreationAuditedEntity;
+import pt.estga.shared.entities.CreationAuditedEntity;
 import pt.estga.mark.enums.TargetType;
 import pt.estga.report.enums.ReportReason;
 import pt.estga.report.enums.ReportStatus;

--- a/report/src/main/java/pt/estga/report/services/ReportQueryService.java
+++ b/report/src/main/java/pt/estga/report/services/ReportQueryService.java
@@ -11,7 +11,6 @@ import pt.estga.report.entities.Report;
 import pt.estga.report.mappers.ReportMapper;
 import pt.estga.report.repositories.ReportRepository;
 
-
 @Service
 @RequiredArgsConstructor
 public class ReportQueryService {

--- a/shared/src/main/java/pt/estga/shared/entities/AuditedEntity.java
+++ b/shared/src/main/java/pt/estga/shared/entities/AuditedEntity.java
@@ -1,4 +1,4 @@
-package pt.estga.shared.audit;
+package pt.estga.shared.entities;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import pt.estga.shared.models.AuditActor;
 
@@ -19,7 +21,7 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
-public abstract class CreationAuditedEntity {
+public abstract class AuditedEntity {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -33,4 +35,14 @@ public abstract class CreationAuditedEntity {
     })
     protected AuditActor createdBy;
 
+    @LastModifiedDate
+    protected Instant lastModifiedAt;
+
+    @LastModifiedBy
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "id", column = @Column(name = "modified_by_id")),
+            @AttributeOverride(name = "identifier", column = @Column(name = "modified_by_identifier"))
+    })
+    protected AuditActor modifiedBy;
 }

--- a/shared/src/main/java/pt/estga/shared/entities/BaseEntity.java
+++ b/shared/src/main/java/pt/estga/shared/entities/BaseEntity.java
@@ -1,0 +1,42 @@
+package pt.estga.shared.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import pt.estga.shared.enums.EntityStatus;
+
+import java.time.Instant;
+
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity extends AuditedEntity {
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    protected EntityStatus status = EntityStatus.ACTIVE;
+
+    protected Instant deletedAt;
+
+    public void markDeleted() {
+        if (this.deletedAt != null) return;
+        this.deletedAt = Instant.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+
+    public void activate() {
+        this.status = EntityStatus.ACTIVE;
+    }
+
+    public void deactivate() {
+        this.status = EntityStatus.INACTIVE;
+    }
+
+    public void archive() {
+        this.status = EntityStatus.ARCHIVED;
+    }
+}

--- a/shared/src/main/java/pt/estga/shared/entities/CreationAuditedEntity.java
+++ b/shared/src/main/java/pt/estga/shared/entities/CreationAuditedEntity.java
@@ -1,4 +1,4 @@
-package pt.estga.shared.audit;
+package pt.estga.shared.entities;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -8,8 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import pt.estga.shared.models.AuditActor;
 
@@ -21,7 +19,7 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
-public abstract class AuditedEntity {
+public abstract class CreationAuditedEntity {
 
     @CreatedDate
     @Column(nullable = false, updatable = false)
@@ -35,14 +33,4 @@ public abstract class AuditedEntity {
     })
     protected AuditActor createdBy;
 
-    @LastModifiedDate
-    protected Instant lastModifiedAt;
-
-    @LastModifiedBy
-    @Embedded
-    @AttributeOverrides({
-            @AttributeOverride(name = "id", column = @Column(name = "modified_by_id")),
-            @AttributeOverride(name = "identifier", column = @Column(name = "modified_by_identifier"))
-    })
-    protected AuditActor modifiedBy;
 }

--- a/shared/src/main/java/pt/estga/shared/enums/EntityStatus.java
+++ b/shared/src/main/java/pt/estga/shared/enums/EntityStatus.java
@@ -1,0 +1,8 @@
+package pt.estga.shared.enums;
+
+public enum EntityStatus {
+    ACTIVE,
+    INACTIVE,
+    ARCHIVED,
+    DELETED
+}

--- a/shared/src/main/java/pt/estga/shared/repositories/BaseRepository.java
+++ b/shared/src/main/java/pt/estga/shared/repositories/BaseRepository.java
@@ -1,0 +1,15 @@
+package pt.estga.shared.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.NoRepositoryBean;
+import pt.estga.shared.entities.BaseEntity;
+
+@NoRepositoryBean
+public interface BaseRepository<T, ID> extends JpaRepository<T, ID> {
+
+    default void softDelete(T entity) {
+        if (entity instanceof BaseEntity base) {
+            base.markDeleted();
+        }
+    }
+}

--- a/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
+++ b/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
@@ -38,26 +38,6 @@ public class AdministrativeDivisionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @GetMapping
-    public ResponseEntity<List<AdministrativeDivisionDto>> getDivisionsByType(
-            @RequestParam String type,
-            @RequestParam(required = false) boolean withMonuments
-    ) {
-        List<AdministrativeDivision> divisions;
-        int adminLevel = switch (type.toLowerCase()) {
-            case "district" -> 6;
-            case "municipality" -> 7;
-            case "parish" -> 8;
-            default -> throw new IllegalArgumentException("Invalid type: " + type);
-        };
-        if (withMonuments) {
-            divisions = service.findWithMonuments(adminLevel);
-        } else {
-            divisions = service.findByOsmAdminLevel(adminLevel);
-        }
-        return ResponseEntity.ok(mapper.toDtoList(divisions));
-    }
-
     @GetMapping("/districts/{districtId}/municipalities")
     public ResponseEntity<List<AdministrativeDivisionDto>> getMunicipalitiesByDistrict(@PathVariable Long districtId) {
         List<AdministrativeDivision> municipalities = service.findChildren(districtId);

--- a/territory/src/main/java/pt/estga/territory/entities/AdministrativeDivision.java
+++ b/territory/src/main/java/pt/estga/territory/entities/AdministrativeDivision.java
@@ -3,7 +3,7 @@ package pt.estga.territory.entities;
 import jakarta.persistence.*;
 import lombok.*;
 import org.locationtech.jts.geom.Geometry;
-import pt.estga.shared.audit.AuditedEntity;
+import pt.estga.shared.entities.AuditedEntity;
 
 @Entity
 @NoArgsConstructor

--- a/territory/src/main/java/pt/estga/territory/entities/AdministrativeDivision.java
+++ b/territory/src/main/java/pt/estga/territory/entities/AdministrativeDivision.java
@@ -3,7 +3,7 @@ package pt.estga.territory.entities;
 import jakarta.persistence.*;
 import lombok.*;
 import org.locationtech.jts.geom.Geometry;
-import pt.estga.shared.entities.AuditedEntity;
+import pt.estga.shared.entities.BaseEntity;
 
 @Entity
 @NoArgsConstructor
@@ -11,7 +11,7 @@ import pt.estga.shared.entities.AuditedEntity;
 @Getter
 @Setter
 @Builder
-public class AdministrativeDivision extends AuditedEntity {
+public class AdministrativeDivision extends BaseEntity {
 
     @Id
     private Long id;
@@ -26,6 +26,7 @@ public class AdministrativeDivision extends AuditedEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private AdministrativeDivision parent;
 
+    // Todo: create country entity
     private String countryCode;
 
     private int monumentsCount = 0;

--- a/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
+++ b/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
@@ -29,7 +29,4 @@ public interface AdministrativeDivisionRepository extends BaseRepository<Adminis
             "WHERE ST_Contains(d.geometry, ST_SetSRID(ST_Point(:longitude, :latitude), 4326)) " +
             "ORDER BY d.osm_admin_level ASC", nativeQuery = true)
     List<AdministrativeDivision> findByCoordinates(@Param("latitude") double latitude, @Param("longitude") double longitude);
-
-    @Query("SELECT d FROM AdministrativeDivision d WHERE d.osmAdminLevel = :adminLevel AND d.monumentsCount > 0")
-    List<AdministrativeDivision> findWithMonuments(@Param("adminLevel") int adminLevel);
 }

--- a/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
+++ b/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
@@ -5,13 +5,14 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import pt.estga.shared.repositories.BaseRepository;
 import pt.estga.territory.entities.AdministrativeDivision;
 
 import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface AdministrativeDivisionRepository extends JpaRepository<AdministrativeDivision, Long>, JpaSpecificationExecutor<AdministrativeDivision> {
+public interface AdministrativeDivisionRepository extends BaseRepository<AdministrativeDivision, Long>, JpaSpecificationExecutor<AdministrativeDivision> {
     List<AdministrativeDivision> findByOsmAdminLevel(int osmAdminLevel);
 
     List<AdministrativeDivision> findByParentId(Long parentId);

--- a/territory/src/main/java/pt/estga/territory/services/AdministrativeDivisionQueryService.java
+++ b/territory/src/main/java/pt/estga/territory/services/AdministrativeDivisionQueryService.java
@@ -41,16 +41,8 @@ public class AdministrativeDivisionQueryService {
 		return repository.findById(id);
 	}
 
-	public List<AdministrativeDivision> findByOsmAdminLevel(int adminLevel) {
-		return repository.findByOsmAdminLevel(adminLevel);
-	}
-
 	public List<AdministrativeDivision> findChildren(Long parentId) {
 		return repository.findByParentId(parentId);
-	}
-
-	public Optional<AdministrativeDivision> findParentByGeometry(Long childId, int parentLevel) {
-		return repository.findParentByGeometry(childId, parentLevel);
 	}
 
 	public Optional<AdministrativeDivision> findParent(Long childId) {
@@ -59,14 +51,6 @@ public class AdministrativeDivisionQueryService {
 
 	public List<AdministrativeDivision> findByCoordinates(double latitude, double longitude) {
 		return repository.findByCoordinates(latitude, longitude);
-	}
-
-	public List<AdministrativeDivision> findWithMonuments(int adminLevel) {
-		return repository.findWithMonuments(adminLevel);
-	}
-
-	public List<AdministrativeDivision> findAllRoots() {
-		return repository.findAllByParentIsNull();
 	}
 }
 


### PR DESCRIPTION
This pull request introduces several important refactorings and updates across the `mark`, `monument`, and `intake` modules to standardize entity inheritance, update repository patterns, and improve enum usage. The main focus is on replacing custom or legacy base classes and repository interfaces with shared, centralized implementations, as well as updating entity status handling and simplifying some controller endpoints.

**Entity and Repository Refactoring**

* All major entity classes in `mark` and `monument` now extend the shared `BaseEntity` instead of custom or legacy audited entities, promoting consistency and code reuse. (`mark/src/main/java/pt/estga/mark/entities/Mark.java` [[1]](diffhunk://#diff-a49bd206613dcfedb5506e81412a064577a0aba43e20289251c336501461d20eL18-R18) `mark/src/main/java/pt/estga/mark/entities/MarkCategory.java` [[2]](diffhunk://#diff-8dc8871ed2a0ae3b9f788ed6a8a59e8ce63a6fed6c9a23aa63d14d716c306ac0L14-R15) `mark/src/main/java/pt/estga/mark/entities/MarkEvidence.java` [[3]](diffhunk://#diff-423b6437dc9425e7873dc409479f0de609a7bdf5d5d58987e7c7f76ef12ed96eL17-R17) `mark/src/main/java/pt/estga/mark/entities/MarkOccurrence.java` [[4]](diffhunk://#diff-a7877c7f18206073a7f2bd0c00761b44b29f2dd264a5b660fa66eb1529d257afL19-R19) `monument/src/main/java/pt/estga/monument/Monument.java` [[5]](diffhunk://#diff-47454947bd5f8047f6f3e4dff641a0462290c6016022428e583eb72835378568R9-R18)
* All main repository interfaces in `mark` and `monument` modules now extend the shared `BaseRepository`, and in some cases also `JpaSpecificationExecutor`, replacing direct `JpaRepository` usage. This enables more flexible query capabilities and centralized repository logic. (`mark/src/main/java/pt/estga/mark/repositories/MarkCategoryRepository.java` [[1]](diffhunk://#diff-abf6aad0cf34feea4ea4ab8813b5309a9907e0db470edc9804d60d91344e0035L3-R6) `mark/src/main/java/pt/estga/mark/repositories/MarkEvidenceRepository.java` [[2]](diffhunk://#diff-c3eae586aa98e829518daa1f0f6800c7eabbc6ccb959646e15a6c0efa1cd246aL3-R8) `mark/src/main/java/pt/estga/mark/repositories/MarkOccurrenceRepository.java` [[3]](diffhunk://#diff-26e3db4a6259e0f08a0ed719c1df0bc0db88f9ed9ce0b581902392c3be17323fL6-L23) `mark/src/main/java/pt/estga/mark/repositories/MarkRepository.java` [[4]](diffhunk://#diff-06a5193ec8ceeb68c2788b094b9bf919630d25738ec01fdc4739a748ddc8be18L3-R8) `monument/src/main/java/pt/estga/monument/MonumentRepository.java` [[5]](diffhunk://#diff-a2560670a7e7eeb0694a0ad8bac40191e3f63aab2b34447fb08909064b72d490L6-R28)

**Status and Enum Improvements**

* The `SubmissionStatus` enum in the `intake` module has been updated to use more descriptive and general statuses (`PENDING_ANALYSIS`, `ENRICHED`, `ACCEPTED`, `REJECTED`) instead of previous specific terms. All references and usages have been updated accordingly. (`intake/src/main/java/pt/estga/intake/enums/SubmissionStatus.java` [[1]](diffhunk://#diff-fb61de6b80f7b6eade0898317459ce703014de5617edda269dece4f65bc4cb70L4-R7) `intake/src/main/java/pt/estga/intake/services/MarkEvidenceSubmissionService.java` [[2]](diffhunk://#diff-45601e97d0eb77212ad57bd45c44ccb1b7e84c2ca8caadd5e7b629b1cd1ac83dL58-R58)
* The `MonumentRepository` and related queries now use an `EntityStatus` enum instead of a boolean `active` flag, supporting more robust status management. (`monument/src/main/java/pt/estga/monument/MonumentRepository.java` [monument/src/main/java/pt/estga/monument/MonumentRepository.javaL6-R28](diffhunk://#diff-a2560670a7e7eeb0694a0ad8bac40191e3f63aab2b34447fb08909064b72d490L6-R28))

**Controller and API Simplification**

* The `MonumentAdminController` endpoints for creating and updating monuments have been simplified to accept form data via `@ModelAttribute` without requiring multipart file uploads, making the API easier to consume and maintain. (`monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java` [[1]](diffhunk://#diff-265025cb12a0f22d2c107753c673fbdfe7ff47fddca0946ad3712ce1f9228a0bL35-R35) [[2]](diffhunk://#diff-265025cb12a0f22d2c107753c673fbdfe7ff47fddca0946ad3712ce1f9228a0bL54-R55)

**Other Notable Changes**

* Redundant or legacy fields such as `active` flags and some unused imports or methods have been removed from entities and services, further simplifying the codebase. (`mark/src/main/java/pt/estga/mark/entities/Mark.java` [[1]](diffhunk://#diff-a49bd206613dcfedb5506e81412a064577a0aba43e20289251c336501461d20eL46-L47) `mark/src/main/java/pt/estga/mark/entities/MarkOccurrence.java` [[2]](diffhunk://#diff-a7877c7f18206073a7f2bd0c00761b44b29f2dd264a5b660fa66eb1529d257afL45-L47) `monument/src/main/java/pt/estga/monument/Monument.java` [[3]](diffhunk://#diff-47454947bd5f8047f6f3e4dff641a0462290c6016022428e583eb72835378568L49-L51) `mark/src/main/java/pt/estga/mark/services/MarkOccurrenceQueryService.java` [[4]](diffhunk://#diff-92c18d3bbf99a674864da706844815eeaed908fe718ea30edaad8aaecba385dfL20-L23)

**Dependency Cleanup**

* Removed an unused dependency on the `vision` module from the `intake` module's `pom.xml`. (`intake/pom.xml` [intake/pom.xmlL27-L31](diffhunk://#diff-4fbbedb88f776a459ca8a8d301bb468fca129730931be6b2d11b076a88eeb1e7L27-L31))

These changes collectively modernize the codebase, improve maintainability, and align with shared patterns across modules.