### PR TITLE
Refactor/logs

### DIFF
--- a/boot/src/main/resources/application.yml
+++ b/boot/src/main/resources/application.yml
@@ -40,8 +40,7 @@ vision:
 
 logging:
   level:
-    org.springframework: INFO
-    pt.estga: DEBUG
+    root: info
 
 application:
   base-url: https://api.stonemark.pt
@@ -67,6 +66,3 @@ management:
         liveness:
           include: [livenessState]
       validate-group-membership: false
-
-# Note: Prometheus metrics are enabled by adding micrometer-registry-prometheus dependency.
-# Secure actuator endpoints in production via network restrictions or Spring Security.

--- a/chatbot/src/main/java/pt/estga/chatbot/config/TelegramBotInitializer.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/config/TelegramBotInitializer.java
@@ -25,13 +25,13 @@ public class TelegramBotInitializer implements CommandLineRunner {
     @Override
     public void run(String... args) {
         String webhookUrl = baseUrl + webhookPath;
-        log.info("Setting Telegram webhook to: {}", webhookUrl);
+        log.debug("Setting Telegram webhook (url suppressed)");
 
         try {
             SetWebhook setWebhook = new SetWebhook();
             setWebhook.setUrl(webhookUrl);
             telegramBot.execute(setWebhook);
-            log.info("Telegram webhook set successfully");
+            log.debug("Telegram webhook set successfully");
         } catch (TelegramApiException e) {
             log.error("Error setting Telegram webhook: {}", e.getMessage());
         }

--- a/chatbot/src/main/java/pt/estga/chatbot/config/TelegramWebhookRequestLoggingFilter.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/config/TelegramWebhookRequestLoggingFilter.java
@@ -53,7 +53,7 @@ public class TelegramWebhookRequestLoggingFilter extends OncePerRequestFilter {
         var wrapped = new CachedBodyHttpServletRequest(request, bodyBytes);
         int status = 0;
         try {
-            log.info("Incoming request {} {} to webhook path {}", request.getMethod(), request.getRequestURI(), webhookPath);
+            log.debug("Incoming request {} {} to webhook path {}", request.getMethod(), request.getRequestURI(), webhookPath);
             // Log headers of interest
             Collections.list(request.getHeaderNames()).forEach(name -> log.debug("Header: {}={} ", name, request.getHeader(name)));
 
@@ -77,7 +77,7 @@ public class TelegramWebhookRequestLoggingFilter extends OncePerRequestFilter {
                             telegramBot.onWebhookUpdateReceived(update);
                             wrapped.setAttribute("BOT_DISPATCHED", Boolean.TRUE);
                             status = HttpServletResponse.SC_OK;
-                            log.info("Filter handled callback_query and dispatched to bot");
+                            log.debug("Filter handled callback_query and dispatched to bot");
                             return;
                         } catch (Exception e) {
                             log.error("Filter dispatch error invoking bot", e);
@@ -104,19 +104,18 @@ public class TelegramWebhookRequestLoggingFilter extends OncePerRequestFilter {
             }
         } finally {
             // After chain, log request body (if any) and attach it to the request for downstream handlers.
-            byte[] buf = bodyBytes;
             String payload;
-            if (buf.length > 0) {
-                payload = new String(buf, StandardCharsets.UTF_8);
-                log.info("Telegram webhook request body: {}", payload);
+            if (bodyBytes.length > 0) {
+                payload = new String(bodyBytes, StandardCharsets.UTF_8);
+                log.debug("Telegram webhook request body length: {}", bodyBytes.length);
             } else {
                 payload = null;
-                log.info("Telegram webhook request body: <empty>");
+                log.debug("Telegram webhook request body: <empty>");
             }
 
             // Check whether controller set BOT_DISPATCHED attribute on the wrapped request.
             Object dispatched = wrapped.getAttribute("BOT_DISPATCHED");
-            log.info("BOT_DISPATCHED attribute after dispatch: {}", dispatched);
+            log.debug("BOT_DISPATCHED attribute after dispatch: {}", dispatched);
 
             // Controlled fallback: if controller did not handle the request (non-200) and
             // the payload contains a callback_query, parse and dispatch to the bot so
@@ -124,7 +123,7 @@ public class TelegramWebhookRequestLoggingFilter extends OncePerRequestFilter {
             // checking BOT_DISPATCHED attribute.
             if (status != 200 && payload != null && payload.contains("\"callback_query\"") && wrapped.getAttribute("BOT_DISPATCHED") == null) {
                 try {
-                    log.info("Controller returned {} for webhook; attempting fallback dispatch for callback_query", status);
+                    log.debug("Controller returned {} for webhook; attempting fallback dispatch for callback_query", status);
                     var parsed = objectMapper.readValue(payload, com.fasterxml.jackson.databind.JsonNode.class);
                     // Basic sanity check for presence of callback_query node
                     if (parsed != null && parsed.has("callback_query")) {
@@ -133,7 +132,7 @@ public class TelegramWebhookRequestLoggingFilter extends OncePerRequestFilter {
                             var update = objectMapper.treeToValue(parsed, org.telegram.telegrambots.meta.api.objects.Update.class);
                             telegramBot.onWebhookUpdateReceived(update);
                             wrapped.setAttribute("BOT_DISPATCHED", Boolean.TRUE);
-                            log.info("Fallback dispatch: delivered Update to bot");
+                            log.debug("Fallback dispatch: delivered Update to bot");
                         } catch (Exception e) {
                             log.error("Fallback dispatch: error invoking bot", e);
                         }

--- a/chatbot/src/main/java/pt/estga/chatbot/features/verification/handlers/GenerateVerificationCodeHandler.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/features/verification/handlers/GenerateVerificationCodeHandler.java
@@ -29,7 +29,7 @@ public class GenerateVerificationCodeHandler implements ConversationStateHandler
         // Store code in context to display
         context.setVerificationCode(actionCode.getCode());
 
-        log.info("Generated verification code for platform user: {}", platformUserId);
+        log.debug("Generated verification code for platform user: {}", platformUserId);
 
         return HandlerOutcome.SUCCESS;
     }

--- a/chatbot/src/main/java/pt/estga/chatbot/services/ConversationDispatcher.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/services/ConversationDispatcher.java
@@ -60,7 +60,7 @@ public class ConversationDispatcher {
 
         // Determine the next state.
         ConversationState nextState = submissionFlow.getNextState(context, currentState, outcome);
-        log.info("State transition: {} -> {} (outcome: {})", currentState, nextState, outcome);
+        log.debug("State transition: {} -> {} (outcome: {})", currentState, nextState, outcome);
         context.setCurrentState(nextState);
 
         // If the next state is automatic, execute it first to populate context before generating response
@@ -77,7 +77,7 @@ public class ConversationDispatcher {
             // If automatic handler needs state transition, handle it recursively
             if (autoOutcome != HandlerOutcome.SUCCESS && autoOutcome != HandlerOutcome.AWAITING_INPUT) {
                 ConversationState autoNextState = submissionFlow.getNextState(context, nextState, autoOutcome);
-                log.info("Automatic state transition: {} -> {} (outcome: {})", nextState, autoNextState, autoOutcome);
+                log.debug("Automatic state transition: {} -> {} (outcome: {})", nextState, autoNextState, autoOutcome);
                 context.setCurrentState(autoNextState);
             }
         }

--- a/chatbot/src/main/java/pt/estga/chatbot/services/notifications/TelegramNotificationService.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/services/notifications/TelegramNotificationService.java
@@ -39,7 +39,7 @@ public class TelegramNotificationService implements MessengerNotificationService
             }
 
             telegramBot.execute(sendMessage);
-            log.info("Notification sent to Telegram user: {}", recipientId);
+            log.debug("Notification sent to Telegram user: {}", recipientId);
         } catch (TelegramApiException e) {
             log.error("Failed to send notification to Telegram user {}: {}", recipientId, e.getMessage());
         }
@@ -62,7 +62,7 @@ public class TelegramNotificationService implements MessengerNotificationService
                     .build();
 
             telegramBot.dispatchAndSend(menuInput);
-            log.info("Main menu dispatched and sent to Telegram user: {}", recipientId);
+            log.debug("Main menu dispatched and sent to Telegram user: {}", recipientId);
         } catch (NumberFormatException e) {
             log.error("Invalid telegram recipient id '{}': {}", recipientId, e.getMessage());
         }

--- a/chatbot/src/main/java/pt/estga/chatbot/telegram/StonemarkTelegramBot.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/telegram/StonemarkTelegramBot.java
@@ -62,8 +62,7 @@ public class StonemarkTelegramBot extends TelegramWebhookBot {
 
     @Override
     public BotApiMethod<?> onWebhookUpdateReceived(Update update) {
-        log.info("onWebhookUpdateReceived invoked for updateId={}", update == null ? "<null>" : update.getUpdateId());
-        // Synchronous quick-handling: log update type and immediately acknowledge callback queries
+        log.debug("onWebhookUpdateReceived invoked for updateId={}", update == null ? "<null>" : update.getUpdateId());
         try {
             if (update == null) {
                 log.warn("Received null Telegram update");
@@ -81,7 +80,7 @@ public class StonemarkTelegramBot extends TelegramWebhookBot {
                     AnswerCallbackQuery ack = new AnswerCallbackQuery(callbackId);
                     ack.setText("");
                     execute(ack);
-                    log.info("Sent AnswerCallbackQuery ack for id={}", callbackId);
+                    log.debug("Sent AnswerCallbackQuery ack for id={}", callbackId);
                 } catch (TelegramApiException e) {
                     String msg = e.getMessage();
                     if (msg != null && msg.contains("query is too old")) {

--- a/chatbot/src/main/java/pt/estga/chatbot/telegram/TelegramAdapter.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/telegram/TelegramAdapter.java
@@ -145,14 +145,14 @@ public class TelegramAdapter {
 
     private BotInput processImageFile(long chatId, String fileId, String fileName) {
         try {
-            log.info("Processing image file with ID: {} and name: {}", fileId, fileName);
+            log.debug("Processing image file with ID: {} and name: {}", fileId, fileName);
             File downloadedFile = fileService.downloadFile(fileId);
             if (downloadedFile == null || !downloadedFile.exists()) {
                 log.error("Failed to download file or file does not exist. File ID: {}", fileId);
                 return null;
             }
             byte[] photoData = Files.readAllBytes(downloadedFile.toPath());
-            log.info("Successfully read {} bytes from file {}", photoData.length, fileName);
+            log.debug("Successfully read {} bytes from file {}", photoData.length, fileName);
 
             return BotInput.builder()
                     .userId(String.valueOf(chatId))

--- a/chatbot/src/main/java/pt/estga/chatbot/telegram/TelegramBotWebhook.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/telegram/TelegramBotWebhook.java
@@ -5,8 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.HttpStatus;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.telegram.telegrambots.meta.api.methods.BotApiMethod;
 import org.telegram.telegrambots.meta.api.objects.Update;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -22,21 +20,21 @@ public class TelegramBotWebhook {
     public ResponseEntity<Void> handleUpdate(HttpServletRequest request, @RequestBody(required = false) Update update) {
         try {
             if (update == null) {
-                log.info("Received null Telegram update");
+                log.debug("Received null Telegram update");
             } else if (update.hasCallbackQuery() && update.getCallbackQuery() != null) {
-                log.info("Received Telegram callback query id={} data={}", update.getCallbackQuery().getId(), update.getCallbackQuery().getData());
+                log.debug("Received Telegram callback query id={}", update.getCallbackQuery().getId());
             } else if (update.hasMessage() && update.getMessage() != null) {
-                log.info("Received Telegram message updateId={} chatId={}", update.getUpdateId(), update.getMessage().getChatId());
+                log.debug("Received Telegram message updateId={} chatId={}", update.getUpdateId(), update.getMessage().getChatId());
             } else {
-                log.info("Received Telegram update: updateId={}", update.getUpdateId());
+                log.debug("Received Telegram update: updateId={}", update.getUpdateId());
             }
 
-            log.debug("Full Update payload: {}", update);
+            log.trace("Full Update payload: {}", update);
 
             // If the filter pre-dispatched the Update, avoid double-processing but still return OK
             Object dispatched = request.getAttribute("BOT_DISPATCHED");
             if (Boolean.TRUE.equals(dispatched)) {
-                log.info("Skipping controller dispatch because filter already dispatched the Update");
+                log.debug("Skipping controller dispatch because filter already dispatched the Update");
                 return ResponseEntity.ok().build();
             }
 

--- a/chatbot/src/main/java/pt/estga/chatbot/whatsapp/WhatsAppWebhookController.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/whatsapp/WhatsAppWebhookController.java
@@ -27,26 +27,26 @@ public class WhatsAppWebhookController {
     @PostMapping
     public ResponseEntity<Void> onMessage(@RequestBody WhatsAppWebhookPayload payload) {
         try {
-            log.info("Received WhatsApp payload: {}", payload);
+            log.debug("Received WhatsApp payload: {}", payload);
 
             BotInput input = WhatsAppMapper.toBotMessage(payload);
 
             if (input == null) {
-                log.info("Mapper returned null — no actionable message");
+                log.debug("Mapper returned null — no actionable message");
                 return ResponseEntity.ok().build();
             }
 
-            log.info("Mapped BotInput: {}", input);
+            log.debug("Mapped BotInput: {}", input);
 
             List<BotResponse> responses = botEngine.handleInput(input);
             if (responses == null || responses.isEmpty()) {
-                log.info("BotEngine returned no responses");
+                log.debug("BotEngine returned no responses");
                 return ResponseEntity.ok().build();
             }
 
             for (BotResponse response : responses) {
                 try {
-                    log.info("Sending message to {}: {}", input.getChatId(), response.getTextNode());
+                    log.debug("Sending message to {}", input.getChatId());
                     apiClient.sendMessage(String.valueOf(input.getChatId()), response);
                 } catch (Exception e) {
                     log.error("Failed to send message to {}: {}", input.getChatId(), response, e);
@@ -67,13 +67,10 @@ public class WhatsAppWebhookController {
             @RequestParam("hub.mode") String mode,
             @RequestParam("hub.challenge") String challenge,
             @RequestParam("hub.verify_token") String token) {
-
-        log.info("WhatsApp webhook verification request received");
-        log.info("Mode: {}, Challenge: {}, Token: {}", mode, challenge, token);
-        log.info("Expected token: {}", verifyToken);
+        log.debug("WhatsApp webhook verification request received (mode={})", mode);
 
         if ("subscribe".equals(mode) && verifyToken.equals(token)) {
-            log.info("WhatsApp webhook verification successful");
+            log.debug("WhatsApp webhook verification successful");
             return ResponseEntity.ok(challenge);
         } else {
             log.warn("WhatsApp webhook verification failed");

--- a/file/src/main/java/pt/estga/file/services/application/MediaService.java
+++ b/file/src/main/java/pt/estga/file/services/application/MediaService.java
@@ -36,7 +36,7 @@ public class MediaService {
     }
 
     public Resource loadFileById(UUID fileId) {
-        log.info("Loading file with ID: {}", fileId);
+        log.debug("Loading file with ID: {}", fileId);
         MediaFile mediaFile = mediaMetadataService.findById(fileId)
                 .orElseThrow(() -> new FileNotFoundException("MediaFile not found with id: " + fileId));
         return loadFile(mediaFile);

--- a/file/src/main/java/pt/estga/file/services/application/MediaVariantService.java
+++ b/file/src/main/java/pt/estga/file/services/application/MediaVariantService.java
@@ -28,7 +28,7 @@ public class MediaVariantService {
     }
 
     private String findVariantPath(Long mediaId, MediaVariantType type) {
-        log.info("Fetching variant path from DB for media ID: {} type: {}", mediaId, type);
+        log.debug("Fetching variant path from DB for media ID: {} type: {}", mediaId, type);
         return mediaVariantRepository.findByMediaFileIdAndType(mediaId, type)
                 .map(MediaVariant::getStoragePath)
                 .orElseThrow(() -> new FileNotFoundException(

--- a/file/src/main/java/pt/estga/file/services/storage/FileStorageServiceLocalImpl.java
+++ b/file/src/main/java/pt/estga/file/services/storage/FileStorageServiceLocalImpl.java
@@ -26,7 +26,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
         this.rootPath = Paths.get(rootDir).toAbsolutePath().normalize();
 
         try {
-            log.info("Creating storage directory at: {}", rootPath);
+            log.debug("Creating storage directory at: {}", rootPath);
             Files.createDirectories(rootPath);
         } catch (IOException e) {
             log.error("Could not initialize storage directory", e);
@@ -36,7 +36,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
 
     @Override
     public String storeFile(InputStream fileStream, String filename) {
-        log.info("Storing file with filename: {}", filename);
+        log.debug("Storing file with filename: {}", filename);
         if (fileStream == null) {
             log.error("Cannot store empty file stream");
             throw new FileStorageException("Cannot store empty file stream");
@@ -63,7 +63,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
             // Return the relative path (which is the filename passed in)
             // Ensure we use forward slashes for consistency
             String relativePath = filename.replace("\\", "/");
-            log.info("File stored successfully at: {}", relativePath);
+            log.debug("File stored successfully at: {}", relativePath);
             return relativePath;
 
         } catch (IOException e) {
@@ -74,7 +74,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
 
     @Override
     public Resource loadFile(String path) {
-        log.info("Loading file from path: {}", path);
+        log.debug("Loading file from path: {}", path);
         try {
             Path filePath = rootPath.resolve(path).normalize();
             Resource resource = new UrlResource(filePath.toUri());
@@ -84,7 +84,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
                 throw new FileNotFoundException("File not found: " + path);
             }
 
-            log.info("File loaded successfully from path: {}", path);
+            log.debug("File loaded successfully from path: {}", path);
             return resource;
         } catch (MalformedURLException e) {
             log.error("File not found: {}", path, e);
@@ -94,7 +94,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
 
     @Override
     public void deleteFile(String path) {
-        log.info("Deleting file from path: {}", path);
+        log.debug("Deleting file from path: {}", path);
         try {
             Path filePath = rootPath.resolve(path).normalize();
             Files.deleteIfExists(filePath);
@@ -111,7 +111,7 @@ public class FileStorageServiceLocalImpl implements FileStorageService {
                 }
             }
 
-            log.info("File deleted successfully from path: {}", path);
+            log.debug("File deleted successfully from path: {}", path);
         } catch (IOException e) {
             log.error("Could not delete file: {}", path, e);
             throw new FileStorageException("Could not delete file: " + path, e);

--- a/file/src/main/java/pt/estga/file/services/storage/FileStorageServiceMinioImpl.java
+++ b/file/src/main/java/pt/estga/file/services/storage/FileStorageServiceMinioImpl.java
@@ -28,7 +28,7 @@ public class FileStorageServiceMinioImpl implements FileStorageService {
 
     @Override
     public String storeFile(InputStream fileStream, String filename) {
-        log.info("Storing file with filename: {}", filename);
+        log.debug("Storing file with filename: {}", filename);
         if (fileStream == null) {
             log.error("Cannot store empty file stream");
             throw new FileStorageException("Cannot store empty file stream");
@@ -45,7 +45,7 @@ public class FileStorageServiceMinioImpl implements FileStorageService {
                             .build()
             );
 
-            log.info("File stored successfully with object name: {}", filename);
+            log.debug("File stored successfully with object name: {}", filename);
             return filename;
         } catch (MinioException e) {
             log.error("Failed to store file in MinIO", e);
@@ -75,7 +75,7 @@ public class FileStorageServiceMinioImpl implements FileStorageService {
 
     @Override
     public void deleteFile(String path) {
-        log.info("Deleting file from path: {}", path);
+        log.debug("Deleting file from path: {}", path);
         try {
             minioClient.removeObject(
                     RemoveObjectArgs.builder()
@@ -83,7 +83,7 @@ public class FileStorageServiceMinioImpl implements FileStorageService {
                             .object(path)
                             .build()
             );
-            log.info("File deleted successfully from path: {}", path);
+            log.debug("File deleted successfully from path: {}", path);
         } catch (MinioException e) {
             log.error("Could not delete file from MinIO with path: {}", path, e);
             throw new FileStorageException("Could not delete file from MinIO", e);

--- a/vision/src/main/java/pt/estga/vision/VisionClient.java
+++ b/vision/src/main/java/pt/estga/vision/VisionClient.java
@@ -38,7 +38,7 @@ public class VisionClient {
 
         // Determine the MediaType based on the filename
         MediaType fileMediaType = getMediaType(originalFilename);
-        log.info("Determined MediaType for file {}: {}", originalFilename, fileMediaType);
+        log.debug("Determined MediaType for file {}: {}", originalFilename, fileMediaType);
 
         // Use MultipartBodyBuilder to construct the request body
         MultipartBodyBuilder builder = new MultipartBodyBuilder();
@@ -53,7 +53,7 @@ public class VisionClient {
         HttpEntity<MultiValueMap<String, HttpEntity<?>>> requestEntity =
                 new HttpEntity<>(builder.build(), headers);
 
-        log.info("Sending request to detection server at: {}", detectionServerUrl + "/process");
+        log.debug("Sending request to detection server at: {}", detectionServerUrl + "/process");
 
         // Use DetectionResult directly for the response
         ResponseEntity<DetectionResult> response = restTemplate.postForEntity(detectionServerUrl + "/process", requestEntity, DetectionResult.class);
@@ -79,7 +79,7 @@ public class VisionClient {
             } else if (lowerCaseFilename.endsWith(".png")) {
                 fileMediaType = MediaType.IMAGE_PNG;
             }
-            // Add other image types if necessary
+            // Other image types later
         }
         return fileMediaType;
     }


### PR DESCRIPTION
This pull request focuses on reducing log verbosity across several modules by downgrading many `log.info` statements to `log.debug` (and some to `log.trace`). This change makes logs less noisy in production, surfacing only essential information at the info level, while keeping detailed logs available for debugging when needed. Additionally, some minor configuration and import cleanups are included.

**Logging verbosity reduction:**

* Changed most `log.info` statements to `log.debug` throughout the chatbot, file, and notification services, including webhook controllers, Telegram bot handlers, and file storage services, to reduce log output in production. [[1]](diffhunk://#diff-688cedad47e7bc6eab8ba81b4c875668792023c6cd7b997410dd751805e9f907L28-R34) [[2]](diffhunk://#diff-05450728b8ea580ab658745f3fff80eda867278c4d89a5a323ca48d7dfb5933fL56-R56) [[3]](diffhunk://#diff-05450728b8ea580ab658745f3fff80eda867278c4d89a5a323ca48d7dfb5933fL80-R80) [[4]](diffhunk://#diff-05450728b8ea580ab658745f3fff80eda867278c4d89a5a323ca48d7dfb5933fL107-R126) [[5]](diffhunk://#diff-05450728b8ea580ab658745f3fff80eda867278c4d89a5a323ca48d7dfb5933fL136-R135) [[6]](diffhunk://#diff-f6efe139385ad7ef9a42a430c6d9bcd4ecb67664b854beb941c6044bd922046aL32-R32) [[7]](diffhunk://#diff-440e8247442579c64bcd9071a7dc664f7bd915def46a87b48125461419d13230L63-R63) [[8]](diffhunk://#diff-440e8247442579c64bcd9071a7dc664f7bd915def46a87b48125461419d13230L80-R80) [[9]](diffhunk://#diff-1ce44a1a933bf219c04498301661b07286467fcde2ce361dcc8681da9860dbc6L42-R42) [[10]](diffhunk://#diff-1ce44a1a933bf219c04498301661b07286467fcde2ce361dcc8681da9860dbc6L65-R65) [[11]](diffhunk://#diff-ca6618417f95fb5775ebd0f6cb910229f23757bc8b27d725defedfb2294e6030L65-R65) [[12]](diffhunk://#diff-ca6618417f95fb5775ebd0f6cb910229f23757bc8b27d725defedfb2294e6030L84-R83) [[13]](diffhunk://#diff-6fa67185e365d5677b8de1a67f287ada7d97f754b751bfe2f236ab7a5a12a519L148-R155) [[14]](diffhunk://#diff-514b54d1ef6a39ccce8fb855929e75fed00feb2482a83f0ae536206094c91020L25-R37) [[15]](diffhunk://#diff-04a934a3f45f44ff43c5961f9b332769bd457dfc51fe628d1a074c0661eb05d4L30-R49) [[16]](diffhunk://#diff-04a934a3f45f44ff43c5961f9b332769bd457dfc51fe628d1a074c0661eb05d4L70-R73) [[17]](diffhunk://#diff-67c9f3614d800e42bc4ce41654abef2eb9dc999a4f6b5de23351998369b400e1L39-R39) [[18]](diffhunk://#diff-6928af049594f93422740e16bfcacd3d501ebc3f8de5b6f7e6820d610715fcecL31-R31) [[19]](diffhunk://#diff-34cb7774e14dd66f83e97809d6e331c008d537b7b04488792faf02b2efb31c39L29-R29) [[20]](diffhunk://#diff-34cb7774e14dd66f83e97809d6e331c008d537b7b04488792faf02b2efb31c39L39-R39)

* In `TelegramBotWebhook`, some logs were further reduced to `log.trace` for full update payloads, and unnecessary import statements were removed. [[1]](diffhunk://#diff-514b54d1ef6a39ccce8fb855929e75fed00feb2482a83f0ae536206094c91020L8-L9) [[2]](diffhunk://#diff-514b54d1ef6a39ccce8fb855929e75fed00feb2482a83f0ae536206094c91020L25-R37)

**Configuration cleanup:**

* Updated `application.yml` to set the root logging level to `info` and removed some comments related to Prometheus metrics and actuator endpoint security. [[1]](diffhunk://#diff-653ca25fa389485fde35e26a52b12f29e709547245dce43faecdcbdf95d3dbe8L43-R43) [[2]](diffhunk://#diff-653ca25fa389485fde35e26a52b12f29e709547245dce43faecdcbdf95d3dbe8L70-L72)

These changes help ensure that only important operational information is logged at the info level, while detailed request and state transition logs are still available for debugging when the log level is set to debug or trace.