### PR TITLE
Fixes/processing

### DIFF
--- a/mark/src/main/java/pt/estga/mark/repositories/MarkEvidenceRepository.java
+++ b/mark/src/main/java/pt/estga/mark/repositories/MarkEvidenceRepository.java
@@ -18,13 +18,11 @@ public interface MarkEvidenceRepository extends BaseRepository<MarkEvidence, UUI
 		me.occurrence_id,
 		(me.embedding <#> CAST(:vector AS vector)) AS distance
 	FROM mark_evidence me
-	WHERE (:occurrenceId IS NULL OR me.occurrence_id = :occurrenceId)
 	ORDER BY distance ASC
 	LIMIT :k
 	""", nativeQuery = true)
 	List<MarkEvidenceDistanceProjection> findTopKSimilarEvidence(
 			@Param("vector") String vector,
-			@Param("occurrenceId") Long occurrenceId,
 			@Param("k") int k
 	);
 

--- a/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
+++ b/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
@@ -27,8 +27,10 @@ import java.util.stream.Collectors;
 public class SimilarityService {
 
     private final MarkEvidenceRepository evidenceRepository;
-    @Value("${processing.similarity.min-score:0.2}")
+    @Value("${processing.similarity.min-score:0.6}")
     private double minSimilarity;
+    @Value("${processing.similarity.max-distance:0.8}")
+    private double maxDistance;
 
     public List<MarkSuggestion> findSimilar(MarkEvidenceProcessing processing, int k) {
 
@@ -84,6 +86,9 @@ public class SimilarityService {
 
             Double distance = p.getDistance();
             if (distance == null) continue;
+
+            // Discard evidences where raw distance is above configured maximum (if set).
+            if (distance > maxDistance) continue;
 
             // Convert distance (cosine-distance) to similarity. For pgvector '<#>' operator,
             // distance ~= 1 - cosine_similarity for normalized vectors.

--- a/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
+++ b/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
@@ -47,7 +47,7 @@ public class SimilarityService {
         String vector = VectorUtils.toVectorLiteral(processing.getEmbedding());
 
         // Query returns id + occurrence id + distance. We then batch-load full entities to avoid N+1.
-        List<MarkEvidenceDistanceProjection> hits = evidenceRepository.findTopKSimilarEvidence(vector, null, k);
+        List<MarkEvidenceDistanceProjection> hits = evidenceRepository.findTopKSimilarEvidence(vector, k);
 
         if (log.isDebugEnabled()) {
             log.debug("Top {} distances (first 5): {}", hits.size(), hits.stream()

--- a/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
+++ b/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.Objects;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.stream.Collectors;
@@ -31,6 +30,12 @@ public class SimilarityService {
     private double minSimilarity;
     @Value("${processing.similarity.max-distance:0.8}")
     private double maxDistance;
+    /**
+     * If true, apply a small rank-based weight to evidence contributions. When false, all
+     * evidence contributions are treated equally (pure similarity aggregation).
+     */
+    @Value("${processing.similarity.use-rank-weighting:true}")
+    private boolean useRankWeighting;
 
     public List<MarkSuggestion> findSimilar(MarkEvidenceProcessing processing, int k) {
 
@@ -69,7 +74,12 @@ public class SimilarityService {
         Map<UUID, Mark> markByEvidenceId = Map.of();
         if (!idSet.isEmpty()) {
             List<EvidenceMarkProjection> rows = evidenceRepository.findMarksByEvidenceIds(List.copyOf(idSet));
-            markByEvidenceId = rows.stream().collect(Collectors.toMap(EvidenceMarkProjection::getId, EvidenceMarkProjection::getMark));
+            // Use a safe merge function to tolerate duplicate keys in case of bad data or join issues.
+            markByEvidenceId = rows.stream().collect(Collectors.toMap(
+                    EvidenceMarkProjection::getId,
+                    EvidenceMarkProjection::getMark,
+                    (a, b) -> a
+            ));
         }
 
         Set<UUID> seen = new HashSet<>();
@@ -97,8 +107,8 @@ public class SimilarityService {
             // Apply simple quality filter using a configurable minimum similarity
             if (similarity < minSimilarity) continue;
 
-            // Weight contribution by rank (DB order). Higher-ranked evidence has more influence.
-            double weight = 1.0 / (1 + idx);
+            // Weight contribution by rank (DB order) if enabled. Otherwise treat all hits equally.
+            double weight = useRankWeighting ? 1.0 / (1 + idx) : 1.0;
             double weighted = similarity * weight;
 
             scores.merge(mark, weighted, Double::sum);
@@ -110,15 +120,20 @@ public class SimilarityService {
         }
 
         return scores.entrySet().stream()
+                // pre-filter entries with valid weight sums to avoid nulls in the mapping stage
+                .filter(entry -> {
+                    Mark mark = entry.getKey();
+                    Double weightSum = weightSums.get(mark);
+                    if (weightSum == null || weightSum == 0.0) {
+                        log.warn("Invariant violation: weightSum missing for mark {}", mark.getId());
+                        return false;
+                    }
+                    return true;
+                })
                 .map(entry -> {
                     Mark mark = entry.getKey();
                     double totalScore = entry.getValue();
-                    Double weightSum = weightSums.get(mark);
-                    if (weightSum == null || weightSum == 0.0) {
-                        // This should never happen — signal an invariant violation so it can be investigated.
-                        log.warn("Invariant violation: weightSum missing for mark {}", mark.getId());
-                        return null;
-                    }
+                    double weightSum = weightSums.get(mark);
 
                     // Normalize by the total weight to produce a weighted average confidence.
                     double confidence = totalScore / weightSum;
@@ -129,7 +144,6 @@ public class SimilarityService {
                             .confidence(confidence)
                             .build();
                 })
-                .filter(Objects::nonNull)
                 .sorted((a, b) -> Double.compare(b.getConfidence(), a.getConfidence()))
                 .limit(5)
                 .toList();

--- a/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
+++ b/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Set;
+import java.util.Objects;
 import java.util.HashSet;
 import java.util.stream.Collectors;
 
@@ -56,9 +57,10 @@ public class SimilarityService {
                     .toList());
         }
 
-        Map<Mark, Double> scores = new HashMap<>();
-        // Sum of weights per mark — used to normalize weighted scores into a confidence value.
-        Map<Mark, Double> weightSums = new HashMap<>();
+        // Use mark id (Long) as key to avoid relying on entity equals()/hashCode().
+        Map<Long, Double> scores = new HashMap<>();
+        // Sum of weights per mark id — used to normalize weighted scores into a confidence value.
+        Map<Long, Double> weightSums = new HashMap<>();
 
         if (hits.isEmpty()) {
             return List.of();
@@ -78,7 +80,13 @@ public class SimilarityService {
             markByEvidenceId = rows.stream().collect(Collectors.toMap(
                     EvidenceMarkProjection::getId,
                     EvidenceMarkProjection::getMark,
-                    (a, b) -> a
+                    (a, b) -> {
+                        // If duplicates happen, keep the first but log so data issues can be investigated.
+                        if (a != null && b != null && !Objects.equals(a.getId(), b.getId())) {
+                            log.warn("Duplicate mark mapping encountered for same evidence id: keeping mark id {} over {}", a.getId(), b.getId());
+                        }
+                        return a;
+                    }
             ));
         }
 
@@ -93,6 +101,8 @@ public class SimilarityService {
 
             Mark mark = markByEvidenceId.get(id);
             if (mark == null) continue;
+            Long markId = mark.getId();
+            if (markId == null) continue;
 
             Double distance = p.getDistance();
             if (distance == null) continue;
@@ -111,36 +121,55 @@ public class SimilarityService {
             double weight = useRankWeighting ? 1.0 / (1 + idx) : 1.0;
             double weighted = similarity * weight;
 
-            scores.merge(mark, weighted, Double::sum);
-            weightSums.merge(mark, weight, Double::sum);
+            scores.merge(markId, weighted, Double::sum);
+            weightSums.merge(markId, weight, Double::sum);
         }
 
         if (scores.isEmpty()) {
             return List.of();
         }
 
+        // Build a markId -> Mark lookup from the lightweight mapping we fetched earlier.
+        Map<Long, Mark> marksById = markByEvidenceId.values().stream()
+                .filter(m -> m != null && m.getId() != null)
+                .collect(Collectors.toMap(
+                        Mark::getId,
+                        m -> m,
+                        (a, b) -> {
+                            if (a != null && b != null && !Objects.equals(a.getId(), b.getId())) {
+                                log.warn("Duplicate Mark entity for id {} when building marksById; keeping first", a.getId());
+                            }
+                            return a;
+                        }
+                ));
+
         return scores.entrySet().stream()
                 // pre-filter entries with valid weight sums to avoid nulls in the mapping stage
                 .filter(entry -> {
-                    Mark mark = entry.getKey();
-                    Double weightSum = weightSums.get(mark);
+                    Long markId = entry.getKey();
+                    Double weightSum = weightSums.get(markId);
                     if (weightSum == null || weightSum == 0.0) {
-                        log.warn("Invariant violation: weightSum missing for mark {}", mark.getId());
+                        log.warn("Invariant violation: weightSum missing for mark id {}", markId);
+                        return false;
+                    }
+                    // ensure we have the actual Mark entity for the id
+                    if (!marksById.containsKey(markId)) {
+                        log.warn("Missing Mark entity for id {} while aggregating scores", markId);
                         return false;
                     }
                     return true;
                 })
                 .map(entry -> {
-                    Mark mark = entry.getKey();
+                    Long markId = entry.getKey();
                     double totalScore = entry.getValue();
-                    double weightSum = weightSums.get(mark);
+                    double weightSum = weightSums.get(markId);
 
                     // Normalize by the total weight to produce a weighted average confidence.
                     double confidence = totalScore / weightSum;
 
                     return MarkSuggestion.builder()
                             .processing(processing)
-                            .mark(mark)
+                            .mark(marksById.get(markId))
                             .confidence(confidence)
                             .build();
                 })

--- a/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
+++ b/processing/src/main/java/pt/estga/processing/services/SimilarityService.java
@@ -29,8 +29,6 @@ public class SimilarityService {
     private final MarkEvidenceRepository evidenceRepository;
     @Value("${processing.similarity.min-score:0.6}")
     private double minSimilarity;
-    @Value("${processing.similarity.max-distance:0.8}")
-    private double maxDistance;
     /**
      * If true, apply a small rank-based weight to evidence contributions. When false, all
      * evidence contributions are treated equally (pure similarity aggregation).
@@ -74,6 +72,8 @@ public class SimilarityService {
         // Collect unique evidence ids to fetch lightweight mark mapping once.
         Set<UUID> idSet = hits.stream().map(MarkEvidenceDistanceProjection::getId).collect(Collectors.toSet());
         Map<UUID, Mark> markByEvidenceId = Map.of();
+        // build a marksById lookup here to avoid an extra pass later
+        Map<Long, Mark> marksById = new java.util.HashMap<>();
         if (!idSet.isEmpty()) {
             List<EvidenceMarkProjection> rows = evidenceRepository.findMarksByEvidenceIds(List.copyOf(idSet));
             // Use a safe merge function to tolerate duplicate keys in case of bad data or join issues.
@@ -82,12 +82,20 @@ public class SimilarityService {
                     EvidenceMarkProjection::getMark,
                     (a, b) -> {
                         // If duplicates happen, keep the first but log so data issues can be investigated.
+                        // Defensive null checks in case projections unexpectedly contain nulls.
                         if (a != null && b != null && !Objects.equals(a.getId(), b.getId())) {
                             log.warn("Duplicate mark mapping encountered for same evidence id: keeping mark id {} over {}", a.getId(), b.getId());
                         }
                         return a;
                     }
             ));
+            // Populate marksById from the rows in a single pass (avoid extra stream operations).
+            for (EvidenceMarkProjection row : rows) {
+                Mark m = row.getMark();
+                if (m != null && m.getId() != null) {
+                    marksById.putIfAbsent(m.getId(), m);
+                }
+            }
         }
 
         Set<UUID> seen = new HashSet<>();
@@ -95,9 +103,6 @@ public class SimilarityService {
             MarkEvidenceDistanceProjection p = hits.get(idx);
             UUID id = p.getId();
             if (!seen.add(id)) continue; // dedupe
-
-            Long occurrenceId = p.getOccurrenceId();
-            if (occurrenceId == null) continue;
 
             Mark mark = markByEvidenceId.get(id);
             if (mark == null) continue;
@@ -107,17 +112,15 @@ public class SimilarityService {
             Double distance = p.getDistance();
             if (distance == null) continue;
 
-            // Discard evidences where raw distance is above configured maximum (if set).
-            if (distance > maxDistance) continue;
-
             // Convert distance (cosine-distance) to similarity. For pgvector '<#>' operator,
-            // distance ~= 1 - cosine_similarity for normalized vectors.
+            // distance ~= 1 - cosine_similarity for normalized vectors. Use similarity threshold
+            // as the primary filter.
             double similarity = 1.0 - distance;
-
-            // Apply simple quality filter using a configurable minimum similarity
             if (similarity < minSimilarity) continue;
 
             // Weight contribution by rank (DB order) if enabled. Otherwise treat all hits equally.
+            // NOTE: this ranking depends on DB ordering being stable for identical distances;
+            // changes to the vector operator or planner may alter ordering and thus affect weights.
             double weight = useRankWeighting ? 1.0 / (1 + idx) : 1.0;
             double weighted = similarity * weight;
 
@@ -129,21 +132,7 @@ public class SimilarityService {
             return List.of();
         }
 
-        // Build a markId -> Mark lookup from the lightweight mapping we fetched earlier.
-        Map<Long, Mark> marksById = markByEvidenceId.values().stream()
-                .filter(m -> m != null && m.getId() != null)
-                .collect(Collectors.toMap(
-                        Mark::getId,
-                        m -> m,
-                        (a, b) -> {
-                            if (a != null && b != null && !Objects.equals(a.getId(), b.getId())) {
-                                log.warn("Duplicate Mark entity for id {} when building marksById; keeping first", a.getId());
-                            }
-                            return a;
-                        }
-                ));
-
-        return scores.entrySet().stream()
+        List<MarkSuggestion> result = scores.entrySet().stream()
                 // pre-filter entries with valid weight sums to avoid nulls in the mapping stage
                 .filter(entry -> {
                     Long markId = entry.getKey();
@@ -176,5 +165,16 @@ public class SimilarityService {
                 .sorted((a, b) -> Double.compare(b.getConfidence(), a.getConfidence()))
                 .limit(5)
                 .toList();
+
+        // Log summary for observability.
+        if (log.isDebugEnabled()) {
+            Double topConfidence = result.stream().findFirst().map(MarkSuggestion::getConfidence).orElse(null);
+            log.debug("Processing {} → {} suggestions (top confidence={})",
+                    processing.getId(),
+                    result.size(),
+                    topConfidence);
+        }
+
+        return result;
     }
 }


### PR DESCRIPTION
This pull request refactors and improves the similarity suggestion logic in the `SimilarityService`, focusing on efficiency, configurability, and robustness. The changes include updating how evidence and marks are mapped, introducing configurable rank-based weighting, raising the minimum similarity threshold, and improving error handling and logging.

**Similarity computation and data handling improvements:**

* Switched from using `Mark` entities as map keys to using mark IDs (`Long`) for score and weight tracking, improving efficiency and avoiding reliance on entity equality/hashCode. Also added a `marksById` lookup to efficiently retrieve `Mark` entities. [[1]](diffhunk://#diff-65ea1174d5c3ec5c256472b950d37b322e0a3029fcd5b7f4e0f10d39ca88dc8fL52-R61) [[2]](diffhunk://#diff-65ea1174d5c3ec5c256472b950d37b322e0a3029fcd5b7f4e0f10d39ca88dc8fR75-R98) [[3]](diffhunk://#diff-65ea1174d5c3ec5c256472b950d37b322e0a3029fcd5b7f4e0f10d39ca88dc8fL79-R178)
* Enhanced mark-evidence mapping to safely handle duplicate keys and potential data issues, with defensive logging for unexpected situations.
* Improved result aggregation by filtering out invalid or missing data before mapping to `MarkSuggestion`, with detailed logging for invariant violations and missing entities.

**Configurability and algorithm tuning:**

* Added a new configuration property (`processing.similarity.use-rank-weighting`) to optionally apply rank-based weighting to evidence contributions, and increased the minimum similarity threshold from 0.2 to 0.6 (`processing.similarity.min-score`). [[1]](diffhunk://#diff-65ea1174d5c3ec5c256472b950d37b322e0a3029fcd5b7f4e0f10d39ca88dc8fL30-R37) [[2]](diffhunk://#diff-65ea1174d5c3ec5c256472b950d37b322e0a3029fcd5b7f4e0f10d39ca88dc8fL79-R178)
* Updated the similarity query in `MarkEvidenceRepository` to remove the unused `occurrenceId` filter and parameter, simplifying the method signature and usage. [[1]](diffhunk://#diff-c3eae586aa98e829518daa1f0f6800c7eabbc6ccb959646e15a6c0efa1cd246aL21-L27) [[2]](diffhunk://#diff-65ea1174d5c3ec5c256472b950d37b322e0a3029fcd5b7f4e0f10d39ca88dc8fL43-R49)

**Logging and observability:**

* Added debug-level logging to provide insight into the number of suggestions produced and the top confidence score for each processing run, aiding in monitoring and tuning.