### PR TITLE
Refactor/rbac

### DIFF
--- a/boot/src/main/java/pt/estga/boot/config/AppJwtAuthenticationConverter.java
+++ b/boot/src/main/java/pt/estga/boot/config/AppJwtAuthenticationConverter.java
@@ -3,16 +3,11 @@ package pt.estga.boot.config;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 import pt.estga.shared.models.AppPrincipal;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.Collections;
 
 @Component
 public class AppJwtAuthenticationConverter implements Converter<Jwt, AbstractAuthenticationToken> {
@@ -22,32 +17,15 @@ public class AppJwtAuthenticationConverter implements Converter<Jwt, AbstractAut
         Long userId = jwt.getClaim("user_id");
         String username = jwt.getClaim("preferred_username");
 
-        Collection<GrantedAuthority> authorities = extractAuthorities(jwt);
-
         AppPrincipal principal = AppPrincipal.builder()
                 .id(userId)
                 .identifier(username)
                 .password(null)
-                .authorities(authorities)
+                .authorities(Collections.emptyList())
                 .enabled(true)
                 .accountNonLocked(true)
                 .build();
 
-        return new UsernamePasswordAuthenticationToken(principal, null, authorities);
-    }
-
-    private Collection<GrantedAuthority> extractAuthorities(Jwt jwt) {
-        List<GrantedAuthority> authorities = new ArrayList<>();
-
-        Map<String, Object> realmAccess = jwt.getClaim("realm_access");
-        if (realmAccess != null && realmAccess.get("roles") instanceof List<?> roles) {
-            for (Object role : roles) {
-                if (role instanceof String roleName) {
-                    authorities.add(new SimpleGrantedAuthority("ROLE_" + roleName.toUpperCase()));
-                }
-            }
-        }
-
-        return authorities;
+        return new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
     }
 }

--- a/boot/src/main/java/pt/estga/boot/config/AppTokenCustomizer.java
+++ b/boot/src/main/java/pt/estga/boot/config/AppTokenCustomizer.java
@@ -5,9 +5,6 @@ import org.springframework.security.oauth2.server.authorization.token.OAuth2Toke
 import org.springframework.stereotype.Component;
 import pt.estga.shared.models.AppPrincipal;
 
-import java.util.List;
-import java.util.Map;
-
 @Component
 public class AppTokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext> {
 
@@ -16,10 +13,6 @@ public class AppTokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingCont
         if (context.getPrincipal().getPrincipal() instanceof AppPrincipal app) {
             context.getClaims().claim("user_id", app.getId());
             context.getClaims().claim("preferred_username", app.getUsername());
-            context.getClaims().claim("realm_access",
-                    Map.of("roles", List.of(app.getAuthorities().stream()
-                            .map(a -> a.getAuthority().replace("ROLE_", ""))
-                            .toList())));
         }
     }
 }

--- a/boot/src/main/java/pt/estga/boot/config/CacheConfig.java
+++ b/boot/src/main/java/pt/estga/boot/config/CacheConfig.java
@@ -1,30 +1,31 @@
 package pt.estga.boot.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Configuration
+@EnableCaching
 public class CacheConfig {
 
-    private static final List<String> CACHE_NAMES = List.of(
-            "conversations",
-            "user_provisioning"
-    );
+    @Value("${cache.user-permissions.ttl-minutes:15}")
+    private long userPermissionsTtlMinutes;
+
+    @Value("${cache.user-permissions.max-size:1000}")
+    private long userPermissionsMaxSize;
 
     @Bean
     public CacheManager cacheManager() {
-
-        CaffeineCacheManager cacheManager = new CaffeineCacheManager();
-        cacheManager.setCacheNames(CACHE_NAMES);
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("user-permissions");
         cacheManager.setCaffeine(Caffeine.newBuilder()
-                .expireAfterWrite(10, TimeUnit.MINUTES)
-                .maximumSize(1000)
+                .expireAfterWrite(userPermissionsTtlMinutes, TimeUnit.MINUTES)
+                .maximumSize(userPermissionsMaxSize)
                 .recordStats());
         return cacheManager;
     }

--- a/boot/src/main/java/pt/estga/boot/config/GoogleOAuth2UserService.java
+++ b/boot/src/main/java/pt/estga/boot/config/GoogleOAuth2UserService.java
@@ -3,6 +3,7 @@ package pt.estga.boot.config;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
@@ -12,11 +13,15 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import pt.estga.shared.enums.UserRole;
+import pt.estga.user.entities.Role;
 import pt.estga.user.entities.User;
+import pt.estga.user.repositories.RoleRepository;
 import pt.estga.user.repositories.UserRepository;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +29,7 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     private static final Logger log = LoggerFactory.getLogger(GoogleOAuth2UserService.class);
     private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
 
     @Override
     @Transactional
@@ -77,6 +83,7 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 .emailVerified(email != null)
                 .enabled(true)
                 .role(UserRole.USER)
+                .roles(new HashSet<>(Set.of(getDefaultUserRole())))
                 .build();
 
         user = userRepository.save(user);
@@ -85,10 +92,17 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     private static OAuth2User mapToPrincipal(User user, Map<String, Object> attributes) {
-        return new DefaultOAuth2User(
-                List.of(() -> "ROLE_" + user.getRole().name()),
-                attributes,
-                user.getUsername());
+        List<GrantedAuthority> authorities = user.getRoles().stream()
+                .flatMap(role -> role.getPermissions().stream())
+                .map(permission -> (GrantedAuthority) permission::getName)
+                .toList();
+
+        return new DefaultOAuth2User(authorities, attributes, user.getUsername());
+    }
+
+    private Role getDefaultUserRole() {
+        return roleRepository.findByName("USER")
+                .orElseThrow(() -> new IllegalStateException("Default USER role not found in database"));
     }
 
     private String resolveUsername(String email, String givenName, String familyName, String googleSub) {

--- a/boot/src/main/java/pt/estga/boot/config/GoogleOAuth2UserService.java
+++ b/boot/src/main/java/pt/estga/boot/config/GoogleOAuth2UserService.java
@@ -12,7 +12,6 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import pt.estga.shared.legacy.UserRole;
 import pt.estga.user.entities.Role;
 import pt.estga.user.entities.User;
 import pt.estga.user.repositories.RoleRepository;
@@ -82,7 +81,6 @@ public class GoogleOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
                 .googleSub(googleSub)
                 .emailVerified(email != null)
                 .enabled(true)
-                .role(UserRole.USER)
                 .roles(new HashSet<>(Set.of(getDefaultUserRole())))
                 .build();
 

--- a/boot/src/main/java/pt/estga/boot/config/GoogleOAuth2UserService.java
+++ b/boot/src/main/java/pt/estga/boot/config/GoogleOAuth2UserService.java
@@ -12,7 +12,7 @@ import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import pt.estga.shared.enums.UserRole;
+import pt.estga.shared.legacy.UserRole;
 import pt.estga.user.entities.Role;
 import pt.estga.user.entities.User;
 import pt.estga.user.repositories.RoleRepository;

--- a/boot/src/main/java/pt/estga/boot/config/PermissionEnrichmentFilter.java
+++ b/boot/src/main/java/pt/estga/boot/config/PermissionEnrichmentFilter.java
@@ -15,6 +15,15 @@ import pt.estga.user.services.AuthenticationService;
 
 import java.io.IOException;
 
+/**
+ * SOLE SOURCE of authentication enrichment.
+ * Runs after {@code BearerTokenAuthenticationFilter} and before authorization.
+ * Detects a JWT-authenticated principal with empty authorities,
+ * loads permissions from the database via {@link AuthenticationService},
+ * and replaces the {@code SecurityContext} authentication with the enriched principal.
+ *
+ * No other component may construct or modify the authentication authorities.
+ */
 @Component
 @RequiredArgsConstructor
 public class PermissionEnrichmentFilter extends OncePerRequestFilter {

--- a/boot/src/main/java/pt/estga/boot/config/PermissionEnrichmentFilter.java
+++ b/boot/src/main/java/pt/estga/boot/config/PermissionEnrichmentFilter.java
@@ -1,0 +1,57 @@
+package pt.estga.boot.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import pt.estga.shared.models.AppPrincipal;
+import pt.estga.user.services.AuthenticationService;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class PermissionEnrichmentFilter extends OncePerRequestFilter {
+
+    private final AuthenticationService authenticationService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication instanceof UsernamePasswordAuthenticationToken auth
+                && auth.getPrincipal() instanceof AppPrincipal principal
+                && authentication.isAuthenticated()
+                && principal.getAuthorities().isEmpty()) {
+
+            Long userId = principal.getId();
+            if (userId != null) {
+                AppPrincipal enriched = authenticationService.loadUserById(userId);
+
+                if (!enriched.isEnabled() || !enriched.isAccountNonLocked()) {
+                    SecurityContextHolder.clearContext();
+                    response.sendError(HttpServletResponse.SC_FORBIDDEN, "Account is disabled or locked");
+                    return;
+                }
+
+                var enrichedAuth = new UsernamePasswordAuthenticationToken(
+                        enriched,
+                        auth.getCredentials(),
+                        enriched.getAuthorities()
+                );
+
+                SecurityContextHolder.getContext().setAuthentication(enrichedAuth);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/boot/src/main/java/pt/estga/boot/config/PermissionEnrichmentFilter.java
+++ b/boot/src/main/java/pt/estga/boot/config/PermissionEnrichmentFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;

--- a/boot/src/main/java/pt/estga/boot/config/SecurityConfig.java
+++ b/boot/src/main/java/pt/estga/boot/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.oauth2.server.resource.web.authentication.BearerTokenAuthenticationFilter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 
@@ -48,6 +49,7 @@ public class SecurityConfig {
     };
 
     private final AppJwtAuthenticationConverter appJwtAuthenticationConverter;
+    private final PermissionEnrichmentFilter permissionEnrichmentFilter;
 
     @Bean
     @Order(2)
@@ -62,7 +64,6 @@ public class SecurityConfig {
                     config.setAllowCredentials(true);
                     return config;
                 }))
-                /*
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(OPEN_API_ROUTES).permitAll();
                     auth.requestMatchers(PUBLIC_ROUTE).permitAll();
@@ -76,8 +77,6 @@ public class SecurityConfig {
 
                     auth.anyRequest().authenticated();
                 })
-                 */
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
@@ -86,6 +85,7 @@ public class SecurityConfig {
                                 .jwtAuthenticationConverter(appJwtAuthenticationConverter)
                         )
                 )
+                .addFilterAfter(permissionEnrichmentFilter, BearerTokenAuthenticationFilter.class)
                 .logout(logout -> logout
                         .logoutUrl("/api/v1/auth/logout")
                         .logoutSuccessHandler(

--- a/boot/src/main/resources/application.yml
+++ b/boot/src/main/resources/application.yml
@@ -52,6 +52,11 @@ application:
 user:
   delete-after-days: 30
 
+cache:
+  user-permissions:
+    ttl-minutes: 15
+    max-size: 1000
+
 management:
   endpoints:
     web:

--- a/chatbot/src/main/java/pt/estga/chatbot/telegram/services/TelegramAuthService.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/telegram/services/TelegramAuthService.java
@@ -2,15 +2,16 @@ package pt.estga.chatbot.telegram.services;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 import pt.estga.chatbot.models.Platform;
 import pt.estga.chatbot.services.AuthService;
 import pt.estga.shared.models.AppPrincipal;
-import pt.estga.shared.utils.SecurityUtils;
 import pt.estga.user.enums.ChatbotPlatform;
 import pt.estga.user.services.ChatbotAccountService;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,7 +34,10 @@ public class TelegramAuthService implements AuthService {
                             .id(user.getId())
                             .identifier(user.getUsername())
                             .password(null)
-                            .authorities(SecurityUtils.mapUserRolesToAuthorities(user.getRole()))
+                            .authorities(user.getRoles().stream()
+                                    .flatMap(role -> role.getPermissions().stream())
+                                    .map(permission -> new SimpleGrantedAuthority(permission.getName()))
+                                    .collect(Collectors.toUnmodifiableSet()))
                             .enabled(user.isEnabled())
                             .accountNonLocked(!user.isAccountLocked())
                             .build();

--- a/chatbot/src/main/java/pt/estga/chatbot/whatsapp/services/WhatsAppAuthService.java
+++ b/chatbot/src/main/java/pt/estga/chatbot/whatsapp/services/WhatsAppAuthService.java
@@ -1,15 +1,16 @@
 package pt.estga.chatbot.whatsapp.services;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 import pt.estga.chatbot.models.Platform;
 import pt.estga.chatbot.services.AuthService;
 import pt.estga.shared.models.AppPrincipal;
-import pt.estga.shared.utils.SecurityUtils;
 import pt.estga.user.enums.ChatbotPlatform;
 import pt.estga.user.services.ChatbotAccountService;
 
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +32,10 @@ public class WhatsAppAuthService implements AuthService {
                             .id(user.getId())
                             .identifier(user.getUsername())
                             .password(null)
-                            .authorities(SecurityUtils.mapUserRolesToAuthorities(user.getRole()))
+                            .authorities(user.getRoles().stream()
+                                    .flatMap(role -> role.getPermissions().stream())
+                                    .map(permission -> new SimpleGrantedAuthority(permission.getName()))
+                                    .collect(Collectors.toUnmodifiableSet()))
                             .enabled(user.isEnabled())
                             .accountNonLocked(!user.isAccountLocked())
                             .build();

--- a/content-import/src/main/java/pt/estga/contentimport/ImportController.java
+++ b/content-import/src/main/java/pt/estga/contentimport/ImportController.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 @Slf4j
 @RestController
 @RequestMapping("/api/v1/admin")
-@PreAuthorize("hasRole('MODERATOR')")
+@PreAuthorize("hasAuthority('IMPORT_DATA')")
 @RequiredArgsConstructor
 @Tag(name = "Imports", description = "Endpoints for importing data.")
 public class ImportController {

--- a/monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java
+++ b/monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java
@@ -21,7 +21,7 @@ import java.net.URI;
 @RequestMapping("/api/v1/admin/monuments")
 @RequiredArgsConstructor
 @Tag(name = "Monuments Management", description = "Management endpoints for monuments.")
-@PreAuthorize("hasRole('MODERATOR')")
+@PreAuthorize("hasAuthority('MONUMENT_WRITE')")
 public class MonumentAdminController {
 
     private final MonumentService service;

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,16 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- Caching -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
         <!-- Utilities & Tools -->
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/review/src/main/java/pt/estga/review/controllers/ModerationController.java
+++ b/review/src/main/java/pt/estga/review/controllers/ModerationController.java
@@ -1,6 +1,8 @@
 package pt.estga.review.controllers;
 
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -18,6 +20,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/v1/admin/moderation")
 @RequiredArgsConstructor
+@PreAuthorize("hasAuthority('REVIEW_MODERATE')")
 public class ModerationController {
 
     private final MarkSuggestionRepository suggestionRepository;

--- a/review/src/main/java/pt/estga/review/controllers/ReviewController.java
+++ b/review/src/main/java/pt/estga/review/controllers/ReviewController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import pt.estga.processing.dtos.MarkSuggestionDto;
 import pt.estga.processing.mappers.MarkSuggestionMapper;
@@ -23,6 +24,7 @@ import java.util.List;
 @RequestMapping("/api/v1/admin/review")
 @RequiredArgsConstructor
 @Tag(name = "Review", description = "Review submissions and manage mark suggestions")
+@PreAuthorize("hasAuthority('REVIEW_MODERATE')")
 public class ReviewController {
 
     private final ReviewService reviewService;

--- a/shared/src/main/java/pt/estga/shared/enums/UserRole.java
+++ b/shared/src/main/java/pt/estga/shared/enums/UserRole.java
@@ -1,9 +1,0 @@
-package pt.estga.shared.enums;
-
-@Deprecated(forRemoval = true)
-public enum UserRole {
-    USER,
-    REVIEWER,
-    MODERATOR,
-    ADMIN
-}

--- a/shared/src/main/java/pt/estga/shared/enums/UserRole.java
+++ b/shared/src/main/java/pt/estga/shared/enums/UserRole.java
@@ -1,5 +1,6 @@
 package pt.estga.shared.enums;
 
+@Deprecated(forRemoval = true)
 public enum UserRole {
     USER,
     REVIEWER,

--- a/shared/src/main/java/pt/estga/shared/security/Permissions.java
+++ b/shared/src/main/java/pt/estga/shared/security/Permissions.java
@@ -1,0 +1,17 @@
+package pt.estga.shared.security;
+
+public final class Permissions {
+
+    private Permissions() {}
+
+    public static final String USER_READ = "USER_READ";
+    public static final String USER_WRITE = "USER_WRITE";
+    public static final String USER_MANAGE = "USER_MANAGE";
+    public static final String MONUMENT_READ = "MONUMENT_READ";
+    public static final String MONUMENT_WRITE = "MONUMENT_WRITE";
+    public static final String REVIEW_SUBMIT = "REVIEW_SUBMIT";
+    public static final String REVIEW_MODERATE = "REVIEW_MODERATE";
+    public static final String CONTACT_MANAGE = "CONTACT_MANAGE";
+    public static final String IMPORT_DATA = "IMPORT_DATA";
+    public static final String CHATBOT_USE = "CHATBOT_USE";
+}

--- a/shared/src/main/java/pt/estga/shared/utils/SecurityUtils.java
+++ b/shared/src/main/java/pt/estga/shared/utils/SecurityUtils.java
@@ -4,7 +4,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import pt.estga.shared.enums.UserRole;
+import pt.estga.shared.legacy.UserRole;
 import pt.estga.shared.interfaces.AuthenticatedPrincipal;
 import pt.estga.shared.models.AppPrincipal;
 

--- a/shared/src/main/java/pt/estga/shared/utils/SecurityUtils.java
+++ b/shared/src/main/java/pt/estga/shared/utils/SecurityUtils.java
@@ -52,6 +52,7 @@ public final class SecurityUtils {
         return Optional.of(p);
     }
 
+    @Deprecated(forRemoval = true)
     public static Collection<? extends GrantedAuthority> mapUserRolesToAuthorities(UserRole role) {
         return switch (role) {
             case ADMIN -> List.of(

--- a/support/src/main/java/pt/estga/support/controllers/ContactRequestAdminController.java
+++ b/support/src/main/java/pt/estga/support/controllers/ContactRequestAdminController.java
@@ -15,7 +15,7 @@ import pt.estga.sharedweb.models.PagedRequest;
 @RequestMapping("/api/v1/admin/contact-requests")
 @RequiredArgsConstructor
 @Tag(name = "Admin Contact Requests", description = "Admin endpoints for contact requests.")
-@PreAuthorize("hasRole('MODERATOR')")
+@PreAuthorize("hasAuthority('CONTACT_MANAGE')")
 public class ContactRequestAdminController {
 
     private final ContactRequestService service;

--- a/user/src/main/java/pt/estga/user/config/RolePermissionSeeder.java
+++ b/user/src/main/java/pt/estga/user/config/RolePermissionSeeder.java
@@ -1,0 +1,82 @@
+package pt.estga.user.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import pt.estga.user.entities.Permission;
+import pt.estga.user.entities.Role;
+import pt.estga.user.repositories.PermissionRepository;
+import pt.estga.user.repositories.RoleRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RolePermissionSeeder {
+
+    private final RoleRepository roleRepository;
+    private final PermissionRepository permissionRepository;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Transactional
+    public void seed() {
+        if (roleRepository.count() > 0 && permissionRepository.count() > 0) {
+            log.info("Roles and permissions already seeded, skipping");
+            return;
+        }
+
+        log.info("Seeding roles and permissions");
+
+        Permission userRead = permissionRepository.save(Permission.builder()
+                .name("USER_READ").description("View user profiles").build());
+        Permission userWrite = permissionRepository.save(Permission.builder()
+                .name("USER_WRITE").description("Edit own profile").build());
+        Permission userManage = permissionRepository.save(Permission.builder()
+                .name("USER_MANAGE").description("Manage all users").build());
+        Permission monumentRead = permissionRepository.save(Permission.builder()
+                .name("MONUMENT_READ").description("View monuments").build());
+        Permission monumentWrite = permissionRepository.save(Permission.builder()
+                .name("MONUMENT_WRITE").description("Create and edit monuments").build());
+        Permission reviewSubmit = permissionRepository.save(Permission.builder()
+                .name("REVIEW_SUBMIT").description("Submit review suggestions").build());
+        Permission reviewModerate = permissionRepository.save(Permission.builder()
+                .name("REVIEW_MODERATE").description("Moderate and manage reviews").build());
+        Permission contactManage = permissionRepository.save(Permission.builder()
+                .name("CONTACT_MANAGE").description("Manage contact requests").build());
+        Permission importData = permissionRepository.save(Permission.builder()
+                .name("IMPORT_DATA").description("Import bulk data").build());
+        Permission chatbotUse = permissionRepository.save(Permission.builder()
+                .name("CHATBOT_USE").description("Use chatbot features").build());
+
+        Map<String, Set<Permission>> rolePermissions = Map.of(
+                "USER", Set.of(userRead, userWrite, monumentRead, chatbotUse),
+                "REVIEWER", Set.of(userRead, userWrite, monumentRead, chatbotUse,
+                        reviewSubmit, reviewModerate),
+                "MODERATOR", Set.of(userRead, userWrite, monumentRead, chatbotUse,
+                        reviewSubmit, reviewModerate,
+                        monumentWrite, contactManage, importData),
+                "ADMIN", Set.of(userRead, userWrite, userManage,
+                        monumentRead, monumentWrite,
+                        reviewSubmit, reviewModerate,
+                        contactManage, importData,
+                        chatbotUse)
+        );
+
+        for (var entry : rolePermissions.entrySet()) {
+            Role role = roleRepository.save(Role.builder()
+                    .name(entry.getKey())
+                    .description("Pre-defined " + entry.getKey().toLowerCase() + " role")
+                    .permissions(entry.getValue())
+                    .build());
+            log.info("Seeded role: {} with {} permissions", role.getName(), entry.getValue().size());
+        }
+
+        log.info("Role and permission seeding complete");
+    }
+}

--- a/user/src/main/java/pt/estga/user/controllers/AccountController.java
+++ b/user/src/main/java/pt/estga/user/controllers/AccountController.java
@@ -86,7 +86,6 @@ public class AccountController {
                 user.getEmail(),
                 user.getFirstName(),
                 user.getLastName(),
-                user.getRole(),
                 user.getPasswordHash() != null,
                 user.isEnabled(),
                 user.isAccountLocked()

--- a/user/src/main/java/pt/estga/user/controllers/UserAdminController.java
+++ b/user/src/main/java/pt/estga/user/controllers/UserAdminController.java
@@ -20,7 +20,7 @@ import pt.estga.user.services.UserService;
 @RequestMapping("/api/v1/admin/users")
 @RequiredArgsConstructor
 @Tag(name = "User Management", description = "Endpoints for managing users (Admin).")
-@PreAuthorize("hasRole('ADMIN')")
+@PreAuthorize("hasAuthority('USER_MANAGE')")
 public class UserAdminController {
 
     private final UserService service;

--- a/user/src/main/java/pt/estga/user/dtos/MeDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/MeDto.java
@@ -1,14 +1,11 @@
 package pt.estga.user.dtos;
 
-import pt.estga.shared.enums.UserRole;
-
 public record MeDto(
         Long id,
         String username,
         String email,
         String firstName,
         String lastName,
-        UserRole role,
         boolean passwordSet,
         boolean enabled,
         boolean accountLocked

--- a/user/src/main/java/pt/estga/user/dtos/UserDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/UserDto.java
@@ -2,9 +2,9 @@ package pt.estga.user.dtos;
 
 import lombok.*;
 import pt.estga.file.dtos.MediaFileDto;
-import pt.estga.shared.enums.UserRole;
 
 import java.time.Instant;
+import java.util.Set;
 
 @Builder
 public record UserDto(
@@ -14,6 +14,6 @@ public record UserDto(
         String username,
         String email,
         MediaFileDto photo,
-        UserRole role,
+        Set<String> roles,
         Instant createdAt
 ) { }

--- a/user/src/main/java/pt/estga/user/dtos/UserPublicDto.java
+++ b/user/src/main/java/pt/estga/user/dtos/UserPublicDto.java
@@ -2,7 +2,6 @@ package pt.estga.user.dtos;
 
 import lombok.Builder;
 import pt.estga.sharedweb.annotations.Filterable;
-import pt.estga.shared.enums.UserRole;
 
 @Builder
 public record UserPublicDto(
@@ -10,6 +9,5 @@ public record UserPublicDto(
         @Filterable String username,
         @Filterable String firstName,
         @Filterable String lastName,
-        @Filterable UserRole role,
         Long photoId
 ) { }

--- a/user/src/main/java/pt/estga/user/entities/Permission.java
+++ b/user/src/main/java/pt/estga/user/entities/Permission.java
@@ -1,0 +1,39 @@
+package pt.estga.user.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Entity
+@Table(name = "permissions")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class Permission implements Serializable {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    private String description;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Permission that = (Permission) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/user/src/main/java/pt/estga/user/entities/Role.java
+++ b/user/src/main/java/pt/estga/user/entities/Role.java
@@ -1,0 +1,50 @@
+package pt.estga.user.entities;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+@Entity
+@Table(name = "roles")
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class Role implements Serializable {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String name;
+
+    private String description;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "role_permissions",
+            joinColumns = @JoinColumn(name = "role_id"),
+            inverseJoinColumns = @JoinColumn(name = "permission_id")
+    )
+    @Builder.Default
+    private Set<Permission> permissions = new HashSet<>();
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Role role = (Role) o;
+        return Objects.equals(id, role.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/user/src/main/java/pt/estga/user/entities/User.java
+++ b/user/src/main/java/pt/estga/user/entities/User.java
@@ -2,9 +2,7 @@ package pt.estga.user.entities;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
 import pt.estga.shared.entities.BaseEntity;
-import pt.estga.shared.legacy.UserRole;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -38,10 +36,6 @@ public class User extends BaseEntity implements Serializable {
 
     @Builder.Default
     private boolean emailVerified = false;
-
-    @Deprecated
-    @Enumerated(EnumType.STRING)
-    private UserRole role;
 
     @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(

--- a/user/src/main/java/pt/estga/user/entities/User.java
+++ b/user/src/main/java/pt/estga/user/entities/User.java
@@ -4,7 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import pt.estga.shared.entities.BaseEntity;
-import pt.estga.shared.enums.UserRole;
+import pt.estga.shared.legacy.UserRole;
 
 import java.io.Serial;
 import java.io.Serializable;

--- a/user/src/main/java/pt/estga/user/entities/User.java
+++ b/user/src/main/java/pt/estga/user/entities/User.java
@@ -9,7 +9,9 @@ import pt.estga.shared.enums.UserRole;
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Entity
 @Table(name = "_user")
@@ -37,8 +39,18 @@ public class User extends BaseEntity implements Serializable {
     @Builder.Default
     private boolean emailVerified = false;
 
+    @Deprecated
     @Enumerated(EnumType.STRING)
     private UserRole role;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "user_roles",
+            joinColumns = @JoinColumn(name = "user_id"),
+            inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    @Builder.Default
+    private Set<Role> roles = new HashSet<>();
 
     @Column(name = "password_hash")
     private String passwordHash;

--- a/user/src/main/java/pt/estga/user/mappers/UserMapper.java
+++ b/user/src/main/java/pt/estga/user/mappers/UserMapper.java
@@ -5,7 +5,11 @@ import org.mapstruct.MappingTarget;
 import pt.estga.user.dtos.ProfileUpdateRequestDto;
 import pt.estga.user.dtos.UserPublicDto;
 import pt.estga.user.dtos.UserDto;
+import pt.estga.user.entities.Role;
 import pt.estga.user.entities.User;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
@@ -21,5 +25,10 @@ public interface UserMapper {
     void updateFromDto(UserDto dto, @MappingTarget User user);
 
     void update(User source, @MappingTarget User target);
+
+    default Set<String> rolesToStringSet(Set<Role> roles) {
+        if (roles == null) return Set.of();
+        return roles.stream().map(Role::getName).collect(Collectors.toSet());
+    }
 
 }

--- a/user/src/main/java/pt/estga/user/mappers/UserMapper.java
+++ b/user/src/main/java/pt/estga/user/mappers/UserMapper.java
@@ -1,6 +1,7 @@
 package pt.estga.user.mappers;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import pt.estga.user.dtos.ProfileUpdateRequestDto;
 import pt.estga.user.dtos.UserPublicDto;
@@ -18,10 +19,12 @@ public interface UserMapper {
 
     UserPublicDto toPublicDto(User user);
 
+    @Mapping(target = "roles", ignore = true)
     User toEntity(UserDto dto);
 
     void update(@MappingTarget User user, ProfileUpdateRequestDto dto);
 
+    @Mapping(target = "roles", ignore = true)
     void updateFromDto(UserDto dto, @MappingTarget User user);
 
     void update(User source, @MappingTarget User target);

--- a/user/src/main/java/pt/estga/user/repositories/PermissionRepository.java
+++ b/user/src/main/java/pt/estga/user/repositories/PermissionRepository.java
@@ -1,0 +1,14 @@
+package pt.estga.user.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pt.estga.user.entities.Permission;
+
+import java.util.Optional;
+
+@Repository
+public interface PermissionRepository extends JpaRepository<Permission, Long> {
+
+    Optional<Permission> findByName(String name);
+
+}

--- a/user/src/main/java/pt/estga/user/repositories/RoleRepository.java
+++ b/user/src/main/java/pt/estga/user/repositories/RoleRepository.java
@@ -1,0 +1,14 @@
+package pt.estga.user.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import pt.estga.user.entities.Role;
+
+import java.util.Optional;
+
+@Repository
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+    Optional<Role> findByName(String name);
+
+}

--- a/user/src/main/java/pt/estga/user/repositories/UserRepository.java
+++ b/user/src/main/java/pt/estga/user/repositories/UserRepository.java
@@ -23,4 +23,10 @@ public interface UserRepository extends BaseRepository<User, Long>, JpaSpecifica
 
     boolean existsByUsername(String username);
 
+    @Query("SELECT DISTINCT u FROM User u " +
+           "LEFT JOIN FETCH u.roles r " +
+           "LEFT JOIN FETCH r.permissions " +
+           "WHERE u.id = :id")
+    Optional<User> findByIdWithRolesAndPermissions(@Param("id") Long id);
+
 }

--- a/user/src/main/java/pt/estga/user/services/AuthenticationService.java
+++ b/user/src/main/java/pt/estga/user/services/AuthenticationService.java
@@ -1,0 +1,70 @@
+package pt.estga.user.services;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pt.estga.shared.models.AppPrincipal;
+import pt.estga.sharedweb.exceptions.ResourceNotFoundException;
+import pt.estga.user.entities.User;
+import pt.estga.user.repositories.UserRepository;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AuthenticationService {
+
+    private final UserRepository userRepository;
+    private final CacheManager cacheManager;
+
+    private static final String CACHE_NAME = "user-permissions";
+
+    @Transactional(readOnly = true)
+    public AppPrincipal loadUserById(Long userId) {
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        if (cache != null) {
+            AppPrincipal cached = cache.get(userId, AppPrincipal.class);
+            if (cached != null) {
+                return cached;
+            }
+        }
+
+        AppPrincipal principal = fetchPrincipal(userId);
+        if (cache != null) {
+            cache.put(userId, principal);
+        }
+        return principal;
+    }
+
+    public void invalidateCache(Long userId) {
+        Cache cache = cacheManager.getCache(CACHE_NAME);
+        if (cache != null) {
+            cache.evict(userId);
+        }
+    }
+
+    private AppPrincipal fetchPrincipal(Long userId) {
+        User user = userRepository.findByIdWithRolesAndPermissions(userId)
+                .orElseThrow(() -> new ResourceNotFoundException("User with id " + userId + " not found"));
+
+        Collection<GrantedAuthority> authorities = user.getRoles().stream()
+                .flatMap(role -> role.getPermissions().stream())
+                .map(permission -> new SimpleGrantedAuthority(permission.getName()))
+                .collect(Collectors.toUnmodifiableSet());
+
+        return AppPrincipal.builder()
+                .id(user.getId())
+                .identifier(user.getUsername())
+                .password(null)
+                .authorities(authorities)
+                .enabled(user.isEnabled())
+                .accountNonLocked(!user.isAccountLocked())
+                .build();
+    }
+}

--- a/user/src/main/java/pt/estga/user/services/SasUserDetailsService.java
+++ b/user/src/main/java/pt/estga/user/services/SasUserDetailsService.java
@@ -7,12 +7,13 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import pt.estga.shared.models.AppPrincipal;
 import pt.estga.user.entities.User;
 import pt.estga.user.repositories.UserRepository;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -21,12 +22,17 @@ public class SasUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByUsername(username)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+        User user = userRepository.findByIdWithRolesAndPermissions(
+                userRepository.findByUsername(username)
+                        .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username))
+                        .getId());
 
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+        Collection<GrantedAuthority> authorities = user.getRoles().stream()
+                .flatMap(role -> role.getPermissions().stream())
+                .map(permission -> new SimpleGrantedAuthority(permission.getName()))
+                .collect(Collectors.toUnmodifiableSet());
 
         return AppPrincipal.builder()
                 .id(user.getId())

--- a/user/src/main/java/pt/estga/user/services/SasUserDetailsService.java
+++ b/user/src/main/java/pt/estga/user/services/SasUserDetailsService.java
@@ -24,10 +24,12 @@ public class SasUserDetailsService implements UserDetailsService {
     @Override
     @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = userRepository.findByIdWithRolesAndPermissions(
-                userRepository.findByUsername(username)
-                        .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username))
-                        .getId());
+        Long userId = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username))
+                .getId();
+
+        User user = userRepository.findByIdWithRolesAndPermissions(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
 
         Collection<GrantedAuthority> authorities = user.getRoles().stream()
                 .flatMap(role -> role.getPermissions().stream())

--- a/user/src/main/java/pt/estga/user/services/UserService.java
+++ b/user/src/main/java/pt/estga/user/services/UserService.java
@@ -25,6 +25,7 @@ public class UserService {
     private final ChatbotAccountRepository chatbotAccountRepository;
     private final QueryProcessor<User> queryProcessor;
     private final UserMapper mapper;
+    private final AuthenticationService authenticationService;
 
     public Page<UserDto> search(PagedRequest request) {
         QueryResult<User> result = queryProcessor.process(request);
@@ -65,7 +66,9 @@ public class UserService {
         User existing = repository.findById(user.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("User with id " + user.getId() + " not found"));
         mapper.update(user, existing);
-        return repository.save(existing);
+        User saved = repository.save(existing);
+        authenticationService.invalidateCache(saved.getId());
+        return saved;
     }
 
     @Transactional
@@ -77,6 +80,7 @@ public class UserService {
                 .orElseThrow(() -> new ResourceNotFoundException("User with id " + id + " not found"));
         mapper.updateFromDto(dto, existing);
         User saved = repository.save(existing);
+        authenticationService.invalidateCache(saved.getId());
         return mapper.toDto(saved);
     }
 


### PR DESCRIPTION
This pull request introduces a major overhaul of the authentication and authorization system, moving from role-based to fine-grained, permission-based access control. It also adds a new permission enrichment filter that dynamically loads user permissions after authentication, and introduces cache configuration for user permissions. The changes affect both the backend authentication flow and how permissions are checked throughout the application.

Key changes include:

**Authentication and Authorization Overhaul:**

* Replaced role-based authority extraction with permission-based authorities throughout the authentication flow. JWT tokens are now issued without embedded roles/permissions, and authorities are set as empty lists during authentication. Instead, a new `PermissionEnrichmentFilter` loads permissions from the database after authentication and populates the user's authorities. This ensures that permissions are always up-to-date and sourced from the database only. (`AppJwtAuthenticationConverter.java`, `AppTokenCustomizer.java`, `PermissionEnrichmentFilter.java`, `SecurityConfig.java`) [[1]](diffhunk://#diff-79d08ca75cb7255f0e27067ce02af3d91b729187479b82074b4dcf6eccd734c2L6-R10) [[2]](diffhunk://#diff-79d08ca75cb7255f0e27067ce02af3d91b729187479b82074b4dcf6eccd734c2L25-R29) [[3]](diffhunk://#diff-be305cef8a7dec3597a1f8f371814fd98f1838ff5ac27ba73b606d4106164f9bL8-L10) [[4]](diffhunk://#diff-be305cef8a7dec3597a1f8f371814fd98f1838ff5ac27ba73b606d4106164f9bL19-L22) [[5]](diffhunk://#diff-686fe3398af61416bc3e8cc4a93589825555b62c9447b471f701972c490245a7R1-R65) [[6]](diffhunk://#diff-2184217dbbff686dd04be5e284221bdf6f3b3edd4cc3abdf2bac12d96ee61263R12) [[7]](diffhunk://#diff-2184217dbbff686dd04be5e284221bdf6f3b3edd4cc3abdf2bac12d96ee61263R52) [[8]](diffhunk://#diff-2184217dbbff686dd04be5e284221bdf6f3b3edd4cc3abdf2bac12d96ee61263L65) [[9]](diffhunk://#diff-2184217dbbff686dd04be5e284221bdf6f3b3edd4cc3abdf2bac12d96ee61263L79-L80) [[10]](diffhunk://#diff-2184217dbbff686dd04be5e284221bdf6f3b3edd4cc3abdf2bac12d96ee61263R88)

* Updated OAuth2 (Google) and chatbot authentication services to assign authorities based on user permissions (not roles), reflecting the new permission-based model. (`GoogleOAuth2UserService.java`, `TelegramAuthService.java`, `WhatsAppAuthService.java`) [[1]](diffhunk://#diff-479d3d63acf730e3fdd89a6bde65c4821b65715d7e86915aa0ffe491f6496ae1R6) [[2]](diffhunk://#diff-479d3d63acf730e3fdd89a6bde65c4821b65715d7e86915aa0ffe491f6496ae1L14-R31) [[3]](diffhunk://#diff-479d3d63acf730e3fdd89a6bde65c4821b65715d7e86915aa0ffe491f6496ae1L79-R84) [[4]](diffhunk://#diff-479d3d63acf730e3fdd89a6bde65c4821b65715d7e86915aa0ffe491f6496ae1L88-R103) [[5]](diffhunk://#diff-f9bbe9422829f036493b4968e3d88baa6995d66b15e3507ba2f1321512165956R5-R14) [[6]](diffhunk://#diff-f9bbe9422829f036493b4968e3d88baa6995d66b15e3507ba2f1321512165956L36-R40) [[7]](diffhunk://#diff-0290e162603856b90f4acd977230c9bfdb6f6cbc4c91c1411c9372e6c7bec347R4-R13) [[8]](diffhunk://#diff-0290e162603856b90f4acd977230c9bfdb6f6cbc4c91c1411c9372e6c7bec347L34-R38)

**Permission-based Endpoint Security:**

* Changed controller security annotations to require specific permissions (e.g., `@PreAuthorize("hasAuthority('MONUMENT_WRITE')")`) instead of roles. This enables more granular access control at the endpoint level. (`ImportController.java`, `MonumentAdminController.java`) [[1]](diffhunk://#diff-45bfd7828e029aca79197c5e0f889235033db77d8b2d81264f0bfa78c3517a61L20-R20) [[2]](diffhunk://#diff-265025cb12a0f22d2c107753c673fbdfe7ff47fddca0946ad3712ce1f9228a0bL24-R24)

**Caching Improvements:**

* Introduced Caffeine-based caching for user permissions, with cache configuration exposed via `application.yml` and settable via environment variables. This improves performance by reducing database lookups for permissions. (`CacheConfig.java`, `application.yml`, `pom.xml`) [[1]](diffhunk://#diff-4ac9fbcf6275907e18c7eab7fefee3b6f72066277203e5e2b14d0bb7ca5eeb37R4-R28) [[2]](diffhunk://#diff-653ca25fa389485fde35e26a52b12f29e709547245dce43faecdcbdf95d3dbe8R55-R59) [[3]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R160-R169)

**Other:**

* Minor improvements and dependency updates, including enabling Spring caching and adding required dependencies for Caffeine cache. [[1]](diffhunk://#diff-4ac9fbcf6275907e18c7eab7fefee3b6f72066277203e5e2b14d0bb7ca5eeb37R4-R28) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R160-R169)
* Added missing Swagger annotation for the review moderation controller.

These changes collectively modernize the security model, making it more flexible and maintainable by decoupling permissions from roles and ensuring that authorities are always sourced from the latest database state.