### PR TITLE
Feat/territory

### DIFF
--- a/content-import/src/main/java/pt/estga/contentimport/mappers/DivisionFeatureMapper.java
+++ b/content-import/src/main/java/pt/estga/contentimport/mappers/DivisionFeatureMapper.java
@@ -36,7 +36,6 @@ public class DivisionFeatureMapper {
         if (!props.hasNonNull("admin_level")) return Optional.empty();
 
         int adminLevel = props.path("admin_level").asInt(-1);
-        if (adminLevel != 6 && adminLevel != 7 && adminLevel != 8) return Optional.empty();
 
         String name = resolveName(props);
         if (name == null || name.isBlank()) return Optional.empty();

--- a/content-import/src/main/java/pt/estga/contentimport/mappers/DivisionFeatureMapper.java
+++ b/content-import/src/main/java/pt/estga/contentimport/mappers/DivisionFeatureMapper.java
@@ -33,9 +33,6 @@ public class DivisionFeatureMapper {
         if (props == null || geomNode == null) return Optional.empty();
 
         if (!"administrative".equals(props.path("boundary").asText())) return Optional.empty();
-        if (!props.hasNonNull("admin_level")) return Optional.empty();
-
-        int adminLevel = props.path("admin_level").asInt(-1);
 
         String name = resolveName(props);
         if (name == null || name.isBlank()) return Optional.empty();
@@ -60,7 +57,6 @@ public class DivisionFeatureMapper {
 
         AdministrativeDivision div = AdministrativeDivision.builder()
                 .id(osmId)
-                .osmAdminLevel(adminLevel)
                 .name(name)
                 .geometry(geometry)
                 .country(providedCountryId == null ? null : Country.builder().id(providedCountryId).build())

--- a/content-import/src/main/java/pt/estga/contentimport/services/DivisionImportService.java
+++ b/content-import/src/main/java/pt/estga/contentimport/services/DivisionImportService.java
@@ -93,7 +93,6 @@ public class DivisionImportService {
                 if (existingOpt.isPresent()) {
                     AdministrativeDivision existing = existingOpt.get();
                     existing.setName(div.getName());
-                    existing.setOsmAdminLevel(div.getOsmAdminLevel());
                     existing.setGeometry(div.getGeometry());
                     existing.setCountry(div.getCountry());
                     batch.add(existing);

--- a/content-import/src/main/java/pt/estga/contentimport/services/MonumentEnricher.java
+++ b/content-import/src/main/java/pt/estga/contentimport/services/MonumentEnricher.java
@@ -6,10 +6,7 @@ import pt.estga.monument.Monument;
 import pt.estga.territory.entities.AdministrativeDivision;
 import pt.estga.territory.repositories.AdministrativeDivisionRepository;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -19,8 +16,8 @@ public class MonumentEnricher {
 
     /**
      * Enrich the monument by setting its administrative division based on coordinates.
-     * Selects the division with the highest non-null osmAdminLevel; if none have a level,
-     * falls back to the first non-null division returned by the repository.
+     * The repository returns divisions ordered by area ascending (smallest = most specific),
+     * so the first result is the deepest/narrowest division containing the point.
      */
     public void enrichWithDivisions(Monument m) {
         if (m.getLocation() == null) return;
@@ -32,15 +29,6 @@ public class MonumentEnricher {
             return;
         }
 
-        Optional<AdministrativeDivision> bestByLevel = divisions.stream()
-            .filter(Objects::nonNull)
-            .filter(d -> d.getOsmAdminLevel() != null)
-            .max(Comparator.comparing(AdministrativeDivision::getOsmAdminLevel));
-
-        AdministrativeDivision best = bestByLevel.orElseGet(() ->
-            divisions.stream().filter(Objects::nonNull).findFirst().orElse(null)
-        );
-
-        m.setDivision(best);
+        m.setDivision(divisions.getFirst());
     }
 }

--- a/shared-core/pom.xml
+++ b/shared-core/pom.xml
@@ -19,11 +19,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>pt.estga</groupId>
-            <artifactId>shared-core</artifactId>
-            <version>${stonemark.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>

--- a/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
+++ b/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
@@ -2,9 +2,7 @@ package pt.estga.territory.controllers;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.web.bind.annotation.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pt.estga.sharedweb.models.PagedRequest;
@@ -14,8 +12,6 @@ import pt.estga.territory.mappers.AdministrativeDivisionMapper;
 import pt.estga.territory.services.DivisionService;
 
 import java.util.List;
-
-@Slf4j
 @RestController
 @RequestMapping("/api/v1/public/divisions")
 @RequiredArgsConstructor
@@ -38,31 +34,15 @@ public class AdministrativeDivisionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @GetMapping("/districts/{districtId}/municipalities")
-    public ResponseEntity<List<AdministrativeDivisionDto>> getMunicipalitiesByDistrict(@PathVariable Long districtId) {
-        List<AdministrativeDivision> municipalities = service.findChildren(districtId);
-        log.info("Municipalities: {}", municipalities);
-        return ResponseEntity.ok(mapper.toDtoList(municipalities));
+    @GetMapping("/{parentId}/children")
+    public ResponseEntity<List<AdministrativeDivisionDto>> getChildren(@PathVariable Long parentId) {
+        List<AdministrativeDivision> children = service.findChildren(parentId);
+        return ResponseEntity.ok(mapper.toDtoList(children));
     }
 
-    @GetMapping("/municipalities/{municipalityId}/parishes")
-    public ResponseEntity<List<AdministrativeDivisionDto>> getParishesByMunicipality(@PathVariable Long municipalityId) {
-        List<AdministrativeDivision> parishes = service.findChildren(municipalityId);
-        log.info("Parishes: {}", parishes);
-        return ResponseEntity.ok(mapper.toDtoList(parishes));
-    }
-
-    @GetMapping("/municipalities/{municipalityId}/district")
-    public ResponseEntity<AdministrativeDivisionDto> getDistrictByMunicipality(@PathVariable Long municipalityId) {
-        return service.findParent(municipalityId)
-                .map(mapper::toDto)
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
-    }
-
-    @GetMapping("/parishes/{parishId}/municipality")
-    public ResponseEntity<AdministrativeDivisionDto> getMunicipalityByParish(@PathVariable Long parishId) {
-        return service.findParent(parishId)
+    @GetMapping("/{childId}/parent")
+    public ResponseEntity<AdministrativeDivisionDto> getParent(@PathVariable Long childId) {
+        return service.findParent(childId)
                 .map(mapper::toDto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());

--- a/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
+++ b/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
@@ -7,11 +7,11 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import pt.estga.sharedweb.models.PagedRequest;
 import pt.estga.territory.dtos.AdministrativeDivisionDto;
-import pt.estga.territory.entities.AdministrativeDivision;
 import pt.estga.territory.mappers.AdministrativeDivisionMapper;
 import pt.estga.territory.services.DivisionService;
 
 import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/public/divisions")
 @RequiredArgsConstructor
@@ -20,6 +20,11 @@ public class AdministrativeDivisionController {
 
     private final DivisionService service;
     private final AdministrativeDivisionMapper mapper;
+
+    @GetMapping
+    public ResponseEntity<List<AdministrativeDivisionDto>> getRoots() {
+        return ResponseEntity.ok(mapper.toDtoList(service.findRoots()));
+    }
 
     @PostMapping("/search")
     public ResponseEntity<Page<AdministrativeDivisionDto>> search(@RequestBody PagedRequest request) {
@@ -34,18 +39,22 @@ public class AdministrativeDivisionController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
-    @GetMapping("/{parentId}/children")
-    public ResponseEntity<List<AdministrativeDivisionDto>> getChildren(@PathVariable Long parentId) {
-        List<AdministrativeDivision> children = service.findChildren(parentId);
-        return ResponseEntity.ok(mapper.toDtoList(children));
+    @GetMapping("/{id}/children")
+    public ResponseEntity<List<AdministrativeDivisionDto>> getChildren(@PathVariable Long id) {
+        return ResponseEntity.ok(mapper.toDtoList(service.findChildren(id)));
     }
 
-    @GetMapping("/{childId}/parent")
-    public ResponseEntity<AdministrativeDivisionDto> getParent(@PathVariable Long childId) {
-        return service.findParent(childId)
+    @GetMapping("/{id}/parent")
+    public ResponseEntity<AdministrativeDivisionDto> getParent(@PathVariable Long id) {
+        return service.findParent(id)
                 .map(mapper::toDto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/{id}/ancestors")
+    public ResponseEntity<List<AdministrativeDivisionDto>> getAncestors(@PathVariable Long id) {
+        return ResponseEntity.ok(mapper.toDtoList(service.findAncestors(id)));
     }
 
     @GetMapping("/coordinates")
@@ -53,7 +62,6 @@ public class AdministrativeDivisionController {
             @RequestParam double latitude,
             @RequestParam double longitude
     ) {
-        List<AdministrativeDivision> divisions = service.findByCoordinates(latitude, longitude);
-        return ResponseEntity.ok(mapper.toDtoList(divisions));
+        return ResponseEntity.ok(mapper.toDtoList(service.findByCoordinates(latitude, longitude)));
     }
 }

--- a/territory/src/main/java/pt/estga/territory/dtos/AdministrativeDivisionDto.java
+++ b/territory/src/main/java/pt/estga/territory/dtos/AdministrativeDivisionDto.java
@@ -5,7 +5,6 @@ import lombok.Builder;
 @Builder
 public record AdministrativeDivisionDto(
     Long id,
-    Integer osmAdminLevel,
     String name,
     Long parentId,
     Integer monumentsCount

--- a/territory/src/main/java/pt/estga/territory/dtos/AdministrativeDivisionRequestDto.java
+++ b/territory/src/main/java/pt/estga/territory/dtos/AdministrativeDivisionRequestDto.java
@@ -4,7 +4,6 @@ import lombok.Builder;
 
 @Builder
 public record AdministrativeDivisionRequestDto(
-        Integer osmAdminLevel,
         String name,
         Long parentId,
         Boolean active

--- a/territory/src/main/java/pt/estga/territory/entities/AdministrativeDivision.java
+++ b/territory/src/main/java/pt/estga/territory/entities/AdministrativeDivision.java
@@ -17,8 +17,6 @@ public class AdministrativeDivision extends BaseEntity {
     @GeneratedValue
     private Long id;
 
-    private Integer osmAdminLevel;
-
     private String name;
 
     @Column(columnDefinition = "geometry")

--- a/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
+++ b/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
@@ -20,13 +20,13 @@ public interface AdministrativeDivisionRepository extends BaseRepository<Adminis
     List<AdministrativeDivision> findAllByParentIsNull();
 
     @Query(value = "SELECT p.* FROM administrative_division p " +
-            "JOIN administrative_division c ON ST_Intersects(p.geometry, c.geometry) " +
-            "WHERE c.id = :childId AND p.osm_admin_level = :parentLevel " +
-            "ORDER BY ST_Area(ST_Intersection(p.geometry, c.geometry)) DESC LIMIT 1", nativeQuery = true)
-    Optional<AdministrativeDivision> findParentByGeometry(@Param("childId") Long childId, @Param("parentLevel") int parentLevel);
+            "JOIN administrative_division c ON ST_Contains(p.geometry, c.geometry) " +
+            "WHERE c.id = :childId AND p.id != :childId " +
+            "ORDER BY ST_Area(p.geometry) ASC LIMIT 1", nativeQuery = true)
+    Optional<AdministrativeDivision> findParentByGeometry(@Param("childId") Long childId);
 
     @Query(value = "SELECT * FROM administrative_division d " +
             "WHERE ST_Contains(d.geometry, ST_SetSRID(ST_Point(:longitude, :latitude), 4326)) " +
-            "ORDER BY d.osm_admin_level ASC", nativeQuery = true)
+            "ORDER BY ST_Area(d.geometry) ASC", nativeQuery = true)
     List<AdministrativeDivision> findByCoordinates(@Param("latitude") double latitude, @Param("longitude") double longitude);
 }

--- a/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
+++ b/territory/src/main/java/pt/estga/territory/repositories/AdministrativeDivisionRepository.java
@@ -13,8 +13,6 @@ import java.util.Optional;
 
 @Repository
 public interface AdministrativeDivisionRepository extends BaseRepository<AdministrativeDivision, Long>, JpaSpecificationExecutor<AdministrativeDivision> {
-    List<AdministrativeDivision> findByOsmAdminLevel(int osmAdminLevel);
-
     List<AdministrativeDivision> findByParentId(Long parentId);
 
     List<AdministrativeDivision> findAllByParentIsNull();

--- a/territory/src/main/java/pt/estga/territory/services/AdministrativeDivisionParentMatchingService.java
+++ b/territory/src/main/java/pt/estga/territory/services/AdministrativeDivisionParentMatchingService.java
@@ -32,31 +32,14 @@ public class AdministrativeDivisionParentMatchingService {
     }
 
     private void matchDivision(AdministrativeDivision division) {
-        Integer parentAdminLevel = getParentAdminLevel(division.getOsmAdminLevel());
-        if (parentAdminLevel == null) {
-            return;
-        }
-
-        Optional<AdministrativeDivision> parentOpt = repository.findParentByGeometry(division.getId(), parentAdminLevel);
+        Optional<AdministrativeDivision> parentOpt = repository.findParentByGeometry(division.getId());
         parentOpt.ifPresent(parent -> {
             division.setParent(parent);
             repository.save(division);
         });
 
         if (parentOpt.isEmpty()) {
-            log.warn("Could not find parent for division '{}' (Level {}) with expected parent admin level {}", division.getName(), division.getOsmAdminLevel(), parentAdminLevel);
+            log.warn("Could not find parent for division '{}'", division.getName());
         }
-    }
-
-    private Integer getParentAdminLevel(int adminLevel) {
-        return switch (adminLevel) {
-            case 8 -> // Parish
-                    7; // Parent is Municipality
-            case 7 -> // Municipality
-                    6; // Parent is District
-            case 6 -> // District
-                    null;
-            default -> null;
-        };
     }
 }

--- a/territory/src/main/java/pt/estga/territory/services/DivisionService.java
+++ b/territory/src/main/java/pt/estga/territory/services/DivisionService.java
@@ -3,6 +3,7 @@ package pt.estga.territory.services;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import pt.estga.sharedweb.filtering.QueryProcessor;
 import pt.estga.sharedweb.models.PagedRequest;
 import pt.estga.sharedweb.models.QueryResult;
@@ -11,6 +12,8 @@ import pt.estga.territory.entities.AdministrativeDivision;
 import pt.estga.territory.mappers.AdministrativeDivisionMapper;
 import pt.estga.territory.repositories.AdministrativeDivisionRepository;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +23,7 @@ import java.util.Optional;
  */
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class DivisionService {
 	
   	private final AdministrativeDivisionRepository repository;
@@ -47,6 +51,27 @@ public class DivisionService {
 
 	public Optional<AdministrativeDivision> findParent(Long childId) {
 		return repository.findById(childId).map(AdministrativeDivision::getParent);
+	}
+
+	public List<AdministrativeDivision> findAncestors(Long childId) {
+		return repository.findById(childId)
+				.map(this::collectAncestors)
+				.orElseGet(Collections::emptyList);
+	}
+
+	private List<AdministrativeDivision> collectAncestors(AdministrativeDivision division) {
+		List<AdministrativeDivision> ancestors = new ArrayList<>();
+		AdministrativeDivision current = division.getParent();
+		while (current != null) {
+			ancestors.add(current);
+			current = current.getParent();
+		}
+		Collections.reverse(ancestors);
+		return ancestors;
+	}
+
+	public List<AdministrativeDivision> findRoots() {
+		return repository.findAllByParentIsNull();
 	}
 
 	public List<AdministrativeDivision> findByCoordinates(double latitude, double longitude) {


### PR DESCRIPTION
This pull request removes all usage of the `osmAdminLevel` (OpenStreetMap administrative level) property from the administrative division domain and refactors related logic to rely solely on geometric relationships and parent-child hierarchy. It also simplifies the API for retrieving division relationships and improves the logic for matching and enriching administrative divisions. Additionally, several endpoints are refactored for a more generic and maintainable structure.

**Administrative Division Model & Data Changes:**

* Removed the `osmAdminLevel` field from the `AdministrativeDivision` entity, DTOs, request DTOs, and all related persistence and mapping logic. All code that previously used or set this property has been updated or removed. [[1]](diffhunk://#diff-40a56e268789054b0078d2d670b6ea0c652089965c6e5dcbe564bc555c31aeccL8) [[2]](diffhunk://#diff-9af731fb189a0b23781c6c59ea29206aea076c142d460a0b169fe2490cbeab34L7) [[3]](diffhunk://#diff-d6c6b9510bf44cffe771326e1d31eddfb0328d98fd76a3746883a0402df1254bL20-L21) [[4]](diffhunk://#diff-48d640aa30e27313955dd68461c6cafcd6b52e44cccd168535ac1d0d0e4d58bdL36-L39) [[5]](diffhunk://#diff-48d640aa30e27313955dd68461c6cafcd6b52e44cccd168535ac1d0d0e4d58bdL64) [[6]](diffhunk://#diff-b797fccc88291e146fd29b8a5d74a73a04ff3efbd876199e4edad92363dd53e6L96) [[7]](diffhunk://#diff-74215a7e9efb44ae8ac7ad3182fab6d351cdb425bd8b702f0a12236fd1a56342L16-R28)

**Repository & Service Logic:**

* Refactored repository queries and matching logic to use geometric containment (`ST_Contains`) and area-based ordering instead of administrative levels. The parent-finding and coordinate-based queries now return the smallest containing division, making the hierarchy purely spatial. [[1]](diffhunk://#diff-74215a7e9efb44ae8ac7ad3182fab6d351cdb425bd8b702f0a12236fd1a56342L16-R28) [[2]](diffhunk://#diff-b61bb095879ce2eb75d4253733180f5b8ce42b4b4bb5da6db5688d5ca3a2746cL35-L61)
* Added new service methods to retrieve all ancestors and root divisions, and marked the service as `@Transactional(readOnly = true)` for improved transaction handling. [[1]](diffhunk://#diff-c30f339fc87758f19e06455aef0462bb0176f21a8b52b8a1c57decd70d16cedcR6) [[2]](diffhunk://#diff-c30f339fc87758f19e06455aef0462bb0176f21a8b52b8a1c57decd70d16cedcR15-R16) [[3]](diffhunk://#diff-c30f339fc87758f19e06455aef0462bb0176f21a8b52b8a1c57decd70d16cedcR26) [[4]](diffhunk://#diff-c30f339fc87758f19e06455aef0462bb0176f21a8b52b8a1c57decd70d16cedcR56-R76)

**API Endpoint Simplification:**

* Replaced specific endpoints for districts, municipalities, and parishes with generic endpoints for retrieving children, parent, ancestors, and roots of any division by ID, making the API more flexible and less hardcoded. [[1]](diffhunk://#diff-c952d1a7f45397a1640bd44ea4ec1908b4b48db1c470aa617a7f11d41ccb7060R24-R28) [[2]](diffhunk://#diff-c952d1a7f45397a1640bd44ea4ec1908b4b48db1c470aa617a7f11d41ccb7060L41-R65)

**Monument Enrichment Logic:**

* Updated the monument enrichment logic to always select the smallest (deepest) containing division based on area, instead of relying on the highest admin level, aligning with the new spatial-only hierarchy. [[1]](diffhunk://#diff-ded49cfc1b25ac78c37e44637642451b3a5f3fd15676e25e0713898f9b705db9L9-L12) [[2]](diffhunk://#diff-ded49cfc1b25ac78c37e44637642451b3a5f3fd15676e25e0713898f9b705db9L22-R20) [[3]](diffhunk://#diff-ded49cfc1b25ac78c37e44637642451b3a5f3fd15676e25e0713898f9b705db9L35-R32)

**Miscellaneous:**

* Cleaned up unused dependencies and imports in affected modules. [[1]](diffhunk://#diff-67488eafdf8b4af1ac887b6b44e5ec93c6abca15e7d1737791f9003cd09ccfbaL21-L25) [[2]](diffhunk://#diff-c952d1a7f45397a1640bd44ea4ec1908b4b48db1c470aa617a7f11d41ccb7060L5-L18)

These changes collectively simplify the model, make the hierarchy more robust to data inconsistencies, and provide a more maintainable and generic API for administrative divisions.