### PR TITLE
Feat/processing

### DIFF
--- a/file/src/main/java/pt/estga/file/listeners/MediaEventListener.java
+++ b/file/src/main/java/pt/estga/file/listeners/MediaEventListener.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import pt.estga.file.entities.MediaFile;
 import pt.estga.file.enums.MediaStatus;
+import pt.estga.file.enums.MediaVariantType;
 import pt.estga.file.events.MediaApprovedEvent;
 import pt.estga.file.events.MediaUploadedEvent;
 import pt.estga.file.services.MediaMetadataService;
@@ -24,15 +25,21 @@ public class MediaEventListener {
     @Async("fileTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onMediaUploaded(MediaUploadedEvent event) {
-        log.info("Media uploaded with ID: {} — variant generation deferred until approval", event.mediaFileId());
+        log.info("Media uploaded with ID: {} — generating optimized variant", event.mediaFileId());
+        try {
+            processingService.process(event.mediaFileId(), MediaVariantType.OPTIMIZED);
+        } catch (Exception e) {
+            log.error("Failed to generate optimized variant for media {} — marking FAILED", event.mediaFileId(), e);
+            markMediaFailed(event.mediaFileId());
+        }
     }
 
     @Async("fileTaskExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onMediaApproved(MediaApprovedEvent event) {
-        log.info("Media approved with ID: {} — starting variant generation", event.mediaFileId());
+        log.info("Media approved with ID: {} — generating display variants", event.mediaFileId());
         try {
-            processingService.process(event.mediaFileId());
+            processingService.process(event.mediaFileId(), MediaVariantType.THUMBNAIL, MediaVariantType.PREVIEW);
         } catch (Exception e) {
             log.error("Unhandled failure processing media {} — marking FAILED", event.mediaFileId(), e);
             markMediaFailed(event.mediaFileId());

--- a/file/src/main/java/pt/estga/file/services/MediaProcessingService.java
+++ b/file/src/main/java/pt/estga/file/services/MediaProcessingService.java
@@ -50,8 +50,13 @@ public class MediaProcessingService {
         }
     }
 
-    public void process(UUID mediaFileId) {
-        log.info("Starting processing for media file ID: {}", mediaFileId);
+    public void process(UUID mediaFileId, MediaVariantType... variantTypes) {
+        List<MediaVariantType> types = List.of(variantTypes);
+        if (types.isEmpty()) {
+            log.debug("No variant types requested for media {} — skipping", mediaFileId);
+            return;
+        }
+        log.info("Starting processing for media file ID: {} (types: {})", mediaFileId, types);
         var timer = metrics.startProcessingTimer();
 
         MediaFile mediaFile = mediaMetadataService.findById(mediaFileId)
@@ -76,13 +81,7 @@ public class MediaProcessingService {
                     return;
                 }
 
-                List<MediaVariantType> variants = List.of(
-                        MediaVariantType.THUMBNAIL,
-                        MediaVariantType.PREVIEW,
-                        MediaVariantType.OPTIMIZED
-                );
-
-                for (MediaVariantType type : variants) {
+                for (MediaVariantType type : types) {
                     if (mediaVariantRepository.existsByMediaFileAndType(mediaFile, type)) {
                         log.debug("Variant {} exists for media {}, skipping.", type, mediaFile.getId());
                         continue;

--- a/intake/src/main/java/pt/estga/intake/services/MarkEvidenceSubmissionSubmitService.java
+++ b/intake/src/main/java/pt/estga/intake/services/MarkEvidenceSubmissionSubmitService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import pt.estga.fileapi.FileStorageOperations;
 import pt.estga.shared.events.AfterCommitEventPublisher;
+import pt.estga.shared.events.ProcessingOutboxPort;
 import pt.estga.intake.entities.MarkEvidenceSubmission;
 import pt.estga.intake.enums.SubmissionStatus;
 import pt.estga.intake.events.MarkEvidenceSubmittedEvent;
@@ -12,6 +13,7 @@ import pt.estga.intake.repositories.MarkEvidenceSubmissionRepository;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -22,6 +24,7 @@ public class MarkEvidenceSubmissionSubmitService {
     private final MarkEvidenceSubmissionRepository submissionRepository;
     private final FileStorageOperations fileStorage;
     private final AfterCommitEventPublisher eventPublisher;
+    private final Optional<ProcessingOutboxPort> outboxPort;
 
     /**
      * Submits a mark evidence submission. The provided submission object already contains user and source information
@@ -52,6 +55,7 @@ public class MarkEvidenceSubmissionSubmitService {
         submission.setStatus(SubmissionStatus.RECEIVED);
         MarkEvidenceSubmission saved = submissionRepository.save(submission);
 
+        outboxPort.ifPresent(port -> port.enqueue(saved.getId()));
         eventPublisher.publish(new MarkEvidenceSubmittedEvent(this, saved.getId()));
 
         log.info("Submission submitted successfully with ID: {}", saved.getId());

--- a/processing/src/main/java/pt/estga/processing/config/ProcessingAsyncConfig.java
+++ b/processing/src/main/java/pt/estga/processing/config/ProcessingAsyncConfig.java
@@ -1,5 +1,6 @@
 package pt.estga.processing.config;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -7,6 +8,8 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableAsync
@@ -14,13 +17,22 @@ import java.util.concurrent.Executor;
 public class ProcessingAsyncConfig {
 
     @Bean(name = "processingTaskExecutor")
-    public Executor processingTaskExecutor() {
+    public Executor processingTaskExecutor(MeterRegistry meterRegistry) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(4);
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(100);
         executor.setThreadNamePrefix("processing-");
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
+
+        meterRegistry.gauge("processing.executor.queue_size", executor,
+                ex -> ex.getThreadPoolExecutor().getQueue().size());
+        meterRegistry.gauge("processing.executor.active_threads", executor,
+                ex -> ex.getThreadPoolExecutor().getActiveCount());
+        meterRegistry.gauge("processing.executor.pool_size", executor,
+                ex -> ex.getThreadPoolExecutor().getPoolSize());
+
         return executor;
     }
 }

--- a/processing/src/main/java/pt/estga/processing/entities/MarkEvidenceProcessing.java
+++ b/processing/src/main/java/pt/estga/processing/entities/MarkEvidenceProcessing.java
@@ -48,6 +48,8 @@ public class MarkEvidenceProcessing {
     @Builder.Default
     private boolean permanent = false;
 
+    private Instant updatedAt;
+
     private String errorMessage;
 
     @OneToMany(mappedBy = "processing")

--- a/processing/src/main/java/pt/estga/processing/entities/MarkEvidenceProcessing.java
+++ b/processing/src/main/java/pt/estga/processing/entities/MarkEvidenceProcessing.java
@@ -37,6 +37,17 @@ public class MarkEvidenceProcessing {
 
     private Instant failedAt;
 
+    @Builder.Default
+    private int retryCount = 0;
+
+    @Builder.Default
+    private int maxRetries = 5;
+
+    private Instant lastRetryAt;
+
+    @Builder.Default
+    private boolean permanent = false;
+
     private String errorMessage;
 
     @OneToMany(mappedBy = "processing")

--- a/processing/src/main/java/pt/estga/processing/entities/ProcessingOutbox.java
+++ b/processing/src/main/java/pt/estga/processing/entities/ProcessingOutbox.java
@@ -1,0 +1,48 @@
+package pt.estga.processing.entities;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.UuidGenerator;
+import pt.estga.processing.enums.ProcessingStatus;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+@Builder
+public class ProcessingOutbox {
+
+    @Id
+    @GeneratedValue
+    @UuidGenerator
+    private UUID id;
+
+    @Column(nullable = false)
+    private Long submissionId;
+
+    @Column(nullable = false)
+    private Instant createdAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProcessingStatus status;
+
+    @Builder.Default
+    private int retryCount = 0;
+
+    private Instant lastRetryAt;
+
+}

--- a/processing/src/main/java/pt/estga/processing/enums/ProcessingStatus.java
+++ b/processing/src/main/java/pt/estga/processing/enums/ProcessingStatus.java
@@ -6,5 +6,6 @@ public enum ProcessingStatus {
     COMPLETED,
     REVIEW_PENDING,
     REVIEWED,
-    FAILED
+    FAILED,
+    DISPATCHED
 }

--- a/processing/src/main/java/pt/estga/processing/repositories/MarkEvidenceProcessingRepository.java
+++ b/processing/src/main/java/pt/estga/processing/repositories/MarkEvidenceProcessingRepository.java
@@ -33,4 +33,9 @@ public interface MarkEvidenceProcessingRepository extends JpaRepository<MarkEvid
 	int updateStatusBySubmissionId(@Param("submissionId") Long submissionId, @Param("status") ProcessingStatus status);
 
 	List<MarkEvidenceProcessing> findByStatusIn(List<ProcessingStatus> statuses);
+
+	@Query("SELECT p FROM MarkEvidenceProcessing p WHERE p.status IN :statuses AND p.permanent = false AND p.retryCount < p.maxRetries")
+	List<MarkEvidenceProcessing> findRetryableByStatusIn(@Param("statuses") List<ProcessingStatus> statuses);
+
+	long countByStatusAndPermanentFalse(ProcessingStatus status);
 }

--- a/processing/src/main/java/pt/estga/processing/repositories/ProcessingOutboxRepository.java
+++ b/processing/src/main/java/pt/estga/processing/repositories/ProcessingOutboxRepository.java
@@ -1,0 +1,17 @@
+package pt.estga.processing.repositories;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import pt.estga.processing.entities.ProcessingOutbox;
+import pt.estga.processing.enums.ProcessingStatus;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ProcessingOutboxRepository extends JpaRepository<ProcessingOutbox, UUID> {
+
+    List<ProcessingOutbox> findByStatusOrderByCreatedAtAsc(ProcessingStatus status, Pageable pageable);
+
+    void deleteBySubmissionId(Long submissionId);
+
+}

--- a/processing/src/main/java/pt/estga/processing/scheduling/ProcessingOutboxPoller.java
+++ b/processing/src/main/java/pt/estga/processing/scheduling/ProcessingOutboxPoller.java
@@ -1,0 +1,53 @@
+package pt.estga.processing.scheduling;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import pt.estga.processing.enums.ProcessingStatus;
+import pt.estga.processing.repositories.ProcessingOutboxRepository;
+import pt.estga.processing.services.processing.AsyncProcessingService;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import java.time.Instant;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ProcessingOutboxPoller {
+
+    private final ProcessingOutboxRepository outboxRepository;
+    private final AsyncProcessingService asyncProcessingService;
+    private final MeterRegistry meterRegistry;
+
+    @Scheduled(fixedDelayString = "${processing.outbox.poll-interval:5000}")
+    public void poll() {
+        try {
+            var pageable = PageRequest.of(0, 20);
+            var pending = outboxRepository.findByStatusOrderByCreatedAtAsc(ProcessingStatus.PENDING, pageable);
+            if (pending == null || pending.isEmpty()) {
+                return;
+            }
+
+            log.debug("Dispatching {} outbox entries", pending.size());
+            for (var entry : pending) {
+                meterRegistry.counter("processing.outbox.dispatched").increment();
+                try {
+                    asyncProcessingService.processAsync(entry.getSubmissionId());
+                    entry.setStatus(ProcessingStatus.DISPATCHED);
+                    entry.setLastRetryAt(Instant.now());
+                } catch (Exception e) {
+                    log.error("Failed to dispatch outbox entry {} for submission {}: {}",
+                            entry.getId(), entry.getSubmissionId(), e.getMessage());
+                    entry.setRetryCount(entry.getRetryCount() + 1);
+                    entry.setLastRetryAt(Instant.now());
+                    meterRegistry.counter("processing.outbox.dispatch_failed").increment();
+                }
+                outboxRepository.save(entry);
+            }
+        } catch (Exception e) {
+            log.error("Outbox poller failed: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/processing/src/main/java/pt/estga/processing/scheduling/ProcessingRetryScheduler.java
+++ b/processing/src/main/java/pt/estga/processing/scheduling/ProcessingRetryScheduler.java
@@ -2,13 +2,18 @@ package pt.estga.processing.scheduling;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import pt.estga.processing.entities.MarkEvidenceProcessing;
 import pt.estga.processing.enums.ProcessingStatus;
 import pt.estga.processing.repositories.MarkEvidenceProcessingRepository;
 import pt.estga.processing.services.processing.AsyncProcessingService;
+import pt.estga.vision.VisionClient;
 import io.micrometer.core.instrument.MeterRegistry;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 @Component
@@ -18,22 +23,79 @@ public class ProcessingRetryScheduler {
 
     private final MarkEvidenceProcessingRepository processingRepository;
     private final AsyncProcessingService asyncProcessingService;
+    private final VisionClient visionClient;
     private final MeterRegistry meterRegistry;
 
-    /**
-     * Periodically retry PENDING and FAILED processing entries.
-     * Interval is configurable via property 'processing.retry.interval' (milliseconds).
-     */
+    @Value("${processing.retry.base-delay-ms:60000}")
+    private long baseDelayMs;
+
+    @Value("${processing.retry.max-delay-ms:1800000}")
+    private long maxDelayMs;
+
+    @Value("${processing.retry.batch-size:5}")
+    private int batchSize;
+
+    @Value("${processing.retry.batch-pause-ms:2000}")
+    private long batchPauseMs;
+
     @Scheduled(fixedDelayString = "${processing.retry.interval:60000}")
     public void retryPending() {
         try {
-            var pending = processingRepository.findByStatusIn(List.of(ProcessingStatus.PENDING, ProcessingStatus.FAILED));
-            if (pending == null || pending.isEmpty()) {
+            if (!visionClient.isAvailable()) {
+                log.debug("Vision service unavailable — skipping retry cycle");
+                meterRegistry.counter("processing.retry.skipped", "reason", "vision_unavailable").increment();
                 return;
             }
-            log.info("Retrying {} pending/failed processing entries", pending.size());
+
+            var retryable = processingRepository.findRetryableByStatusIn(
+                    List.of(ProcessingStatus.PENDING, ProcessingStatus.FAILED));
+            if (retryable == null || retryable.isEmpty()) {
+                return;
+            }
+
+            var dueNow = retryable.stream()
+                    .filter(this::isBackoffElapsed)
+                    .toList();
+
+            int skipped = retryable.size() - dueNow.size();
+            if (skipped > 0) {
+                log.debug("Skipping {} entries still in backoff ({} due now)", skipped, dueNow.size());
+                meterRegistry.counter("processing.retry.backoff_skipped").increment(skipped);
+            }
+
+            if (dueNow.isEmpty()) {
+                return;
+            }
+
+            log.info("Retrying {} processing entries in batches of {}", dueNow.size(), batchSize);
             meterRegistry.counter("processing.retry.invocations").increment();
-            for (var p : pending) {
+            dispatchInBatches(dueNow);
+
+        } catch (Exception e) {
+            log.error("Error while retrying pending processing entries: {}", e.getMessage(), e);
+        }
+    }
+
+    private boolean isBackoffElapsed(MarkEvidenceProcessing p) {
+        if (p.getLastRetryAt() == null) {
+            return true;
+        }
+        long delayMs = computeBackoff(p.getRetryCount());
+        Instant nextAttempt = p.getLastRetryAt().plus(Duration.ofMillis(delayMs));
+        return Instant.now().isAfter(nextAttempt);
+    }
+
+    private long computeBackoff(int retryCount) {
+        long delay = baseDelayMs * (1L << Math.min(retryCount, 10));
+        return Math.min(delay, maxDelayMs);
+    }
+
+    private void dispatchInBatches(List<MarkEvidenceProcessing> entries) {
+        for (int i = 0; i < entries.size(); i += batchSize) {
+            int end = Math.min(i + batchSize, entries.size());
+            var batch = entries.subList(i, end);
+
+            for (var p : batch) {
                 Long submissionId = p.getSubmission() != null ? p.getSubmission().getId() : null;
                 if (submissionId == null) {
                     log.warn("Skipping processing entry {} with no submission linked", p.getId());
@@ -42,8 +104,15 @@ public class ProcessingRetryScheduler {
                 meterRegistry.counter("processing.retry.scheduled").increment();
                 asyncProcessingService.processAsync(submissionId);
             }
-        } catch (Exception e) {
-            log.error("Error while retrying pending processing entries: {}", e.getMessage(), e);
+
+            if (end < entries.size()) {
+                try {
+                    Thread.sleep(batchPauseMs);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
         }
     }
 }

--- a/processing/src/main/java/pt/estga/processing/services/outbox/ProcessingOutboxPortImpl.java
+++ b/processing/src/main/java/pt/estga/processing/services/outbox/ProcessingOutboxPortImpl.java
@@ -1,0 +1,29 @@
+package pt.estga.processing.services.outbox;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import pt.estga.processing.entities.ProcessingOutbox;
+import pt.estga.processing.enums.ProcessingStatus;
+import pt.estga.processing.repositories.ProcessingOutboxRepository;
+import pt.estga.shared.events.ProcessingOutboxPort;
+
+import java.time.Instant;
+
+@Service
+@RequiredArgsConstructor
+public class ProcessingOutboxPortImpl implements ProcessingOutboxPort {
+
+    private final ProcessingOutboxRepository outboxRepository;
+
+    @Override
+    @Transactional
+    public void enqueue(Long submissionId) {
+        ProcessingOutbox outbox = ProcessingOutbox.builder()
+                .submissionId(submissionId)
+                .createdAt(Instant.now())
+                .status(ProcessingStatus.PENDING)
+                .build();
+        outboxRepository.save(outbox);
+    }
+}

--- a/processing/src/main/java/pt/estga/processing/services/processing/ProcessingServiceImpl.java
+++ b/processing/src/main/java/pt/estga/processing/services/processing/ProcessingServiceImpl.java
@@ -222,10 +222,14 @@ public class ProcessingServiceImpl implements ProcessingService {
     }
 
     protected void setProcessingPending(UUID processingId) {
-        processingRepository.findById(processingId).ifPresent(p -> {
-            p.setStatus(ProcessingStatus.PENDING);
-            processingRepository.save(p);
-        });
+        transactionTemplate.executeWithoutResult(status ->
+            processingRepository.findById(processingId).ifPresent(p -> {
+                p.setStatus(ProcessingStatus.PENDING);
+                p.setLastRetryAt(Instant.now());
+                p.setRetryCount(p.getRetryCount() + 1);
+                processingRepository.save(p);
+            })
+        );
     }
 
     /**
@@ -233,59 +237,61 @@ public class ProcessingServiceImpl implements ProcessingService {
      * Records metrics (failure counter and processing duration).
      */
     protected void setProcessingFailed(UUID processingId, String message, boolean permanent, long startNanos) {
-        processingRepository.findById(processingId).ifPresent(p -> {
-            p.setStatus(ProcessingStatus.FAILED);
-            p.setFailedAt(Instant.now());
-            p.setErrorMessage(message);
-            processingRepository.save(p);
+        transactionTemplate.executeWithoutResult(status ->
+            processingRepository.findById(processingId).ifPresent(p -> {
+                p.setStatus(ProcessingStatus.FAILED);
+                p.setFailedAt(Instant.now());
+                p.setLastRetryAt(Instant.now());
+                p.setRetryCount(p.getRetryCount() + 1);
+                p.setPermanent(permanent);
+                p.setErrorMessage(message);
+                processingRepository.save(p);
 
-            // metrics
-            meterRegistry.counter("processing.submissions.failed", "permanent", String.valueOf(permanent)).increment();
-            long durationNanos = System.nanoTime() - startNanos;
-            meterRegistry.timer("processing.submissions.duration", "result", "failed").record(Duration.ofNanos(durationNanos));
-            // Observability: log duration and that it failed
-            long durationMs = TimeUnit.NANOSECONDS.toMillis(durationNanos);
-            Long submissionId = p.getSubmission() != null ? p.getSubmission().getId() : null;
-            log.info("Processing {} failed for submission {} after {} ms: {}", processingId, submissionId, durationMs, message);
-        });
+                // metrics
+                meterRegistry.counter("processing.submissions.failed", "permanent", String.valueOf(permanent)).increment();
+                long durationNanos = System.nanoTime() - startNanos;
+                meterRegistry.timer("processing.submissions.duration", "result", "failed").record(Duration.ofNanos(durationNanos));
+                long durationMs = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+                Long submissionId = p.getSubmission() != null ? p.getSubmission().getId() : null;
+                log.info("Processing {} failed for submission {} after {} ms: {}", processingId, submissionId, durationMs, message);
+            })
+        );
     }
 
     /**
      * Finalize successful processing: persist embedding and suggestions, mark completed and record metrics.
      */
     protected void finalizeProcessingSuccess(UUID processingId, float[] embedding, List<MarkSuggestion> suggestions, long startNanos) {
-        processingRepository.findById(processingId).ifPresent(p -> {
-            p.setEmbedding(embedding);
-            p.setStatus(ProcessingStatus.COMPLETED);
-            p.setProcessedAt(Instant.now());
-            // remove previous suggestions to avoid duplicates on reprocessing
-            suggestionRepository.deleteByProcessingId(p.getId());
-                if (suggestions != null && !suggestions.isEmpty()) {
-                // Ensure each suggestion references the managed processing entity
-                suggestions.forEach(s -> s.setProcessing(p));
-                // Persist suggestions in batch
-                suggestions.forEach(s -> s.setId(null));
-                suggestionRepository.saveAll(suggestions);
-            }
-            // Persist normalized embedding (embedding parameter was normalized earlier in the flow)
-            float[] normalizedToSave = pt.estga.shared.utils.VectorUtils.normalize(embedding);
-            if (normalizedToSave != null) {
-                p.setEmbedding(normalizedToSave);
-            } else {
-                // fallback: save raw embedding if normalization somehow failed
+        transactionTemplate.executeWithoutResult(status ->
+            processingRepository.findById(processingId).ifPresent(p -> {
                 p.setEmbedding(embedding);
-            }
-            processingRepository.save(p);
+                p.setStatus(ProcessingStatus.COMPLETED);
+                p.setProcessedAt(Instant.now());
+                p.setRetryCount(0);
+                p.setLastRetryAt(null);
+                p.setPermanent(false);
+                suggestionRepository.deleteByProcessingId(p.getId());
+                if (suggestions != null && !suggestions.isEmpty()) {
+                    suggestions.forEach(s -> s.setProcessing(p));
+                    suggestions.forEach(s -> s.setId(null));
+                    suggestionRepository.saveAll(suggestions);
+                }
+                float[] normalizedToSave = pt.estga.shared.utils.VectorUtils.normalize(embedding);
+                if (normalizedToSave != null) {
+                    p.setEmbedding(normalizedToSave);
+                } else {
+                    p.setEmbedding(embedding);
+                }
+                processingRepository.save(p);
 
-            // metrics
-            meterRegistry.counter("processing.submissions.success").increment();
-            long durationNanos = System.nanoTime() - startNanos;
-            meterRegistry.timer("processing.submissions.duration", "result", "success").record(Duration.ofNanos(durationNanos));
-            // Observability: log duration and suggestion count
-            long durationMs = TimeUnit.NANOSECONDS.toMillis(durationNanos);
-            int suggestionCount = suggestions == null ? 0 : suggestions.size();
-            Long submissionId = p.getSubmission() != null ? p.getSubmission().getId() : null;
-            log.info("Processing {} completed for submission {} after {} ms — suggestions={}", processingId, submissionId, durationMs, suggestionCount);
-        });
+                meterRegistry.counter("processing.submissions.success").increment();
+                long durationNanos = System.nanoTime() - startNanos;
+                meterRegistry.timer("processing.submissions.duration", "result", "success").record(Duration.ofNanos(durationNanos));
+                long durationMs = TimeUnit.NANOSECONDS.toMillis(durationNanos);
+                int suggestionCount = suggestions == null ? 0 : suggestions.size();
+                Long submissionId = p.getSubmission() != null ? p.getSubmission().getId() : null;
+                log.info("Processing {} completed for submission {} after {} ms — suggestions={}", processingId, submissionId, durationMs, suggestionCount);
+            })
+        );
     }
 }

--- a/processing/src/main/java/pt/estga/processing/services/processing/ProcessingServiceImpl.java
+++ b/processing/src/main/java/pt/estga/processing/services/processing/ProcessingServiceImpl.java
@@ -276,12 +276,6 @@ public class ProcessingServiceImpl implements ProcessingService {
                     suggestions.forEach(s -> s.setId(null));
                     suggestionRepository.saveAll(suggestions);
                 }
-                float[] normalizedToSave = pt.estga.shared.utils.VectorUtils.normalize(embedding);
-                if (normalizedToSave != null) {
-                    p.setEmbedding(normalizedToSave);
-                } else {
-                    p.setEmbedding(embedding);
-                }
                 processingRepository.save(p);
 
                 meterRegistry.counter("processing.submissions.success").increment();

--- a/shared-core/src/main/java/pt/estga/shared/events/ProcessingOutboxPort.java
+++ b/shared-core/src/main/java/pt/estga/shared/events/ProcessingOutboxPort.java
@@ -1,0 +1,5 @@
+package pt.estga.shared.events;
+
+public interface ProcessingOutboxPort {
+    void enqueue(Long submissionId);
+}


### PR DESCRIPTION
This pull request introduces a robust outbox-based dispatch and retry mechanism for processing mark evidence submissions, improving reliability, observability, and fault tolerance. The main changes include the introduction of a `ProcessingOutbox` entity and poller, enhanced retry logic with exponential backoff and batching, and improvements to media processing workflows.

**Outbox Pattern for Submission Dispatch:**
- Added the `ProcessingOutbox` entity, repository, and service to queue processing requests for mark evidence submissions, decoupling submission from processing and enabling reliable, idempotent dispatch. (`processing/src/main/java/pt/estga/processing/entities/ProcessingOutbox.java` [[1]](diffhunk://#diff-891627604630d01e1132430cc0e09a43e0969a01fd4ddcab641481434ef75c63R1-R48) `processing/src/main/java/pt/estga/processing/repositories/ProcessingOutboxRepository.java` [[2]](diffhunk://#diff-51bf14374c44c75f086159d58a386e506acc1c2d66e7a01e90e06eb078512e42R1-R17) `processing/src/main/java/pt/estga/processing/services/outbox/ProcessingOutboxPortImpl.java` [[3]](diffhunk://#diff-59e30d3c781e10bbe2c8d947485cb3f306d2f09deba062ee87c13787327e961eR1-R29)
- Implemented the `ProcessingOutboxPoller` scheduled component to periodically dispatch pending outbox entries for processing and mark them as dispatched, with metrics for observability. (`processing/src/main/java/pt/estga/processing/scheduling/ProcessingOutboxPoller.java` [processing/src/main/java/pt/estga/processing/scheduling/ProcessingOutboxPoller.javaR1-R53](diffhunk://#diff-157369cf4f7a933c0efe66c5d2b6bb67671b73149dc480125a8f524011a1b210R1-R53))

**Enhanced Retry and Backoff Logic:**
- Improved the retry scheduler for failed or pending processing entries, adding exponential backoff, batching, and pause between batches, and skipping retries when dependencies (e.g., vision service) are unavailable. (`processing/src/main/java/pt/estga/processing/scheduling/ProcessingRetryScheduler.java` [[1]](diffhunk://#diff-8a07723c195473640bd3e0908c3befb76f3dadd0109edd26ecb7d4b6895f8075R5-R16) [[2]](diffhunk://#diff-8a07723c195473640bd3e0908c3befb76f3dadd0109edd26ecb7d4b6895f8075R26-R98) [[3]](diffhunk://#diff-8a07723c195473640bd3e0908c3befb76f3dadd0109edd26ecb7d4b6895f8075L45-R115)
- Updated the `MarkEvidenceProcessing` entity and repository to support retry counts, backoff, and marking entries as permanently failed after max retries. (`processing/src/main/java/pt/estga/processing/entities/MarkEvidenceProcessing.java` [[1]](diffhunk://#diff-beb9cc6093dab18f1e5ff803cb6d99c14ebb659735ec41cac9891cefb0efc9f1R40-R52) `processing/src/main/java/pt/estga/processing/repositories/MarkEvidenceProcessingRepository.java` [[2]](diffhunk://#diff-9b8abf5dbf05fb38e11d9b614540dbe5004f4374cbb8a3a29be2905f45122f41R36-R40)

**Media Processing Workflow Improvements:**
- Changed media processing to explicitly specify which variants to generate at each event (optimized on upload, display variants on approval), and improved error handling during processing. (`file/src/main/java/pt/estga/file/listeners/MediaEventListener.java` [[1]](diffhunk://#diff-0d5c5f544bf489254aa62693515ed9c7f782866cc27b1d0e5419104fd82cf290R11) [[2]](diffhunk://#diff-0d5c5f544bf489254aa62693515ed9c7f782866cc27b1d0e5419104fd82cf290L27-R42); `file/src/main/java/pt/estga/file/services/MediaProcessingService.java` [[3]](diffhunk://#diff-91f0e5e75c24e8a1ae2892205ab70a4d4d8698a12bbb1ce8c368dec4af49acbdL53-R59) [[4]](diffhunk://#diff-91f0e5e75c24e8a1ae2892205ab70a4d4d8698a12bbb1ce8c368dec4af49acbdL79-R84)

**Integration and Observability:**
- Updated the mark evidence submission service to enqueue submissions in the outbox if the port is available, ensuring reliable downstream processing. (`intake/src/main/java/pt/estga/intake/services/MarkEvidenceSubmissionSubmitService.java` [[1]](diffhunk://#diff-03e57af926933869fcc1333e422cf12c7124f59f1873961b20349eab9b84549aR8-R16) [[2]](diffhunk://#diff-03e57af926933869fcc1333e422cf12c7124f59f1873961b20349eab9b84549aR27) [[3]](diffhunk://#diff-03e57af926933869fcc1333e422cf12c7124f59f1873961b20349eab9b84549aR58)
- Added metrics for async executor queue and thread pool, and improved rejected execution handling for better visibility and resilience. (`processing/src/main/java/pt/estga/processing/config/ProcessingAsyncConfig.java` [processing/src/main/java/pt/estga/processing/config/ProcessingAsyncConfig.javaR3-R35](diffhunk://#diff-d339e0f8099a19f38e20d7ebdd4d394fdcc220053ea830c39237b430fbbfea3aR3-R35))

**Other Improvements:**
- Extended the `ProcessingStatus` enum to include a `DISPATCHED` state for better tracking of outbox entries. (`processing/src/main/java/pt/estga/processing/enums/ProcessingStatus.java` [processing/src/main/java/pt/estga/processing/enums/ProcessingStatus.javaL9-R10](diffhunk://#diff-d52d1e2ff46079df35c2e19b5016cf401ae5dbde61f2aff6c2e7bbe805aef23aL9-R10))

Let me know if you'd like a deeper dive into any of these changes!