### PR TITLE
refactor: convert mappers to static utility classes across all modules

### DIFF
--- a/bookmark/src/main/java/pt/estga/bookmark/services/BookmarkContentResolver.java
+++ b/bookmark/src/main/java/pt/estga/bookmark/services/BookmarkContentResolver.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 public class BookmarkContentResolver {
 
     private final MonumentRepository monumentRepository;
-    private final MonumentMapper monumentMapper;
     private final MarkService markService;
 
     public Map<UUID, BookmarkContent> resolve(List<Bookmark> bookmarks) {
@@ -47,7 +46,7 @@ public class BookmarkContentResolver {
                 .map(b -> Long.parseLong(b.getTargetId()))
                 .toList();
         Map<Long, MonumentDto> monumentMap = monumentRepository.findAllById(ids).stream()
-                .collect(Collectors.toMap(Monument::getId, monumentMapper::toResponseDto));
+                .collect(Collectors.toMap(Monument::getId, MonumentMapper::toResponseDto));
         for (Bookmark b : bookmarks) {
             MonumentDto dto = monumentMap.get(Long.parseLong(b.getTargetId()));
             if (dto != null) {

--- a/file/src/main/java/pt/estga/file/controllers/MediaController.java
+++ b/file/src/main/java/pt/estga/file/controllers/MediaController.java
@@ -36,7 +36,6 @@ public class MediaController {
 
     private final MediaService mediaService;
     private final MediaVariantService mediaVariantService;
-    private final MediaFileMapper mediaFileMapper;
 
     @Operation(summary = "Upload a media file", description = "Uploads a media file and returns its metadata.")
     @ApiResponses(value = {
@@ -55,7 +54,7 @@ public class MediaController {
                 .path("/{id}")
                 .buildAndExpand(mediaFile.getId())
                 .toUri();
-        MediaFileDto dto = mediaFileMapper.toDto(mediaFile);
+        MediaFileDto dto = MediaFileMapper.toDto(mediaFile);
         MediaFileDto dtoWithUrl = new MediaFileDto(
                 dto.id(), dto.filename(), dto.originalFilename(),
                 dto.size(), dto.status(), location.toString()

--- a/file/src/main/java/pt/estga/file/mappers/MediaFileMapper.java
+++ b/file/src/main/java/pt/estga/file/mappers/MediaFileMapper.java
@@ -1,13 +1,13 @@
 package pt.estga.file.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.file.dtos.MediaFileDto;
 import pt.estga.file.entities.MediaFile;
 
-@Component
 public class MediaFileMapper {
 
-    public MediaFileDto toDto(MediaFile entity) {
+    private MediaFileMapper() {}
+
+    public static MediaFileDto toDto(MediaFile entity) {
         if (entity == null) return null;
         return new MediaFileDto(
                 entity.getId(),

--- a/file/src/main/java/pt/estga/file/services/FileStorageAdapter.java
+++ b/file/src/main/java/pt/estga/file/services/FileStorageAdapter.java
@@ -22,7 +22,6 @@ public class FileStorageAdapter implements FileStorageOperations {
 
     private final MediaUploadOrchestrator orchestrator;
     private final MediaFileRepository repository;
-    private final MediaFileMapper mediaFileMapper;
     private final FileStagingService stagingService;
 
     @Override
@@ -30,7 +29,7 @@ public class FileStorageAdapter implements FileStorageOperations {
     public MediaFileDto upload(InputStream data, String originalFilename) {
         try {
             var entity = orchestrator.orchestrateUpload(data, originalFilename);
-            return mediaFileMapper.toDto(entity);
+            return MediaFileMapper.toDto(entity);
         } catch (java.io.IOException e) {
             throw new pt.estga.sharedweb.exceptions.FileStorageException("Failed to upload file", e);
         }
@@ -49,7 +48,7 @@ public class FileStorageAdapter implements FileStorageOperations {
             try (var in = Files.newInputStream(stagedPath)) {
                 var entity = orchestrator.orchestrateUpload(in, originalFilename);
                 stagingService.deleteStagedFile(stagingId, originalFilename);
-                return mediaFileMapper.toDto(entity);
+                return MediaFileMapper.toDto(entity);
             }
         } catch (java.io.IOException e) {
             throw new pt.estga.sharedweb.exceptions.FileStorageException("Failed to commit staged file " + stagingId, e);
@@ -58,6 +57,6 @@ public class FileStorageAdapter implements FileStorageOperations {
 
     @Override
     public Optional<MediaFileDto> findById(UUID id) {
-        return repository.findById(id).map(mediaFileMapper::toDto);
+        return repository.findById(id).map(MediaFileMapper::toDto);
     }
 }

--- a/file/src/test/java/pt/estga/file/controllers/MediaControllerTest.java
+++ b/file/src/test/java/pt/estga/file/controllers/MediaControllerTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import pt.estga.file.dtos.MediaFileDto;
 import pt.estga.file.entities.MediaFile;
-import pt.estga.file.mappers.MediaFileMapper;
 import pt.estga.file.services.application.MediaService;
 import pt.estga.file.services.application.MediaVariantService;
 import pt.estga.sharedweb.exceptions.FileNotFoundException;
@@ -28,10 +27,9 @@ class MediaControllerTest {
 
     private final MediaService mediaService = mock();
     private final MediaVariantService mediaVariantService = mock();
-    private final MediaFileMapper mediaFileMapper = mock();
 
     private final MockMvc mockMvc = MockMvcBuilders.standaloneSetup(
-            new MediaController(mediaService, mediaVariantService, mediaFileMapper)
+            new MediaController(mediaService, mediaVariantService)
     ).setControllerAdvice(new GlobalExceptionHandler()).build();
 
     @Test
@@ -43,7 +41,6 @@ class MediaControllerTest {
         var mediaFile = new MediaFile();
         mediaFile.setId(fileId);
         when(mediaService.upload(any(), anyString(), anyLong())).thenReturn(mediaFile);
-        when(mediaFileMapper.toDto(any())).thenReturn(new MediaFileDto(fileId, "stored.jpg", "test.jpg", 2L, "UPLOADED", null));
 
         mockMvc.perform(multipart("/api/v1/public/media")
                         .file(mockFile)

--- a/mark/src/main/java/pt/estga/mark/mappers/MarkEvidenceMapper.java
+++ b/mark/src/main/java/pt/estga/mark/mappers/MarkEvidenceMapper.java
@@ -1,13 +1,13 @@
 package pt.estga.mark.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.mark.dtos.MarkEvidenceDto;
 import pt.estga.mark.entities.MarkEvidence;
 
-@Component
 public class MarkEvidenceMapper {
 
-    public MarkEvidenceDto toDto(MarkEvidence evidence) {
+    private MarkEvidenceMapper() {}
+
+    public static MarkEvidenceDto toDto(MarkEvidence evidence) {
         if (evidence == null) return null;
         return new MarkEvidenceDto(
                 evidence.getId(),

--- a/mark/src/main/java/pt/estga/mark/mappers/MarkMapper.java
+++ b/mark/src/main/java/pt/estga/mark/mappers/MarkMapper.java
@@ -1,14 +1,14 @@
 package pt.estga.mark.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.mark.dtos.MarkDto;
 import pt.estga.mark.entities.Mark;
 import pt.estga.shared.enums.EntityStatus;
 
-@Component
 public class MarkMapper {
 
-    public MarkDto toDto(Mark mark) {
+    private MarkMapper() {}
+
+    public static MarkDto toDto(Mark mark) {
         if (mark == null) return null;
         return new MarkDto(
                 mark.getId(),

--- a/mark/src/main/java/pt/estga/mark/mappers/MarkOccurrenceMapper.java
+++ b/mark/src/main/java/pt/estga/mark/mappers/MarkOccurrenceMapper.java
@@ -1,24 +1,20 @@
 package pt.estga.mark.mappers;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
 import pt.estga.mark.dtos.MarkOccurrenceDto;
 import pt.estga.mark.entities.MarkOccurrence;
 import pt.estga.shared.enums.EntityStatus;
 
-@Component
-@RequiredArgsConstructor
 public class MarkOccurrenceMapper {
 
-    private final MarkMapper markMapper;
+    private MarkOccurrenceMapper() {}
 
-    public MarkOccurrenceDto toDto(MarkOccurrence entity) {
+    public static MarkOccurrenceDto toDto(MarkOccurrence entity) {
         if (entity == null) return null;
         return new MarkOccurrenceDto(
                 entity.getId(),
                 entity.getMark() != null ? entity.getMark().getId() : null,
                 entity.getMonument() != null ? entity.getMonument().getId() : null,
-                entity.getMark() != null ? markMapper.toDto(entity.getMark()) : null,
+                entity.getMark() != null ? MarkMapper.toDto(entity.getMark()) : null,
                 null,
                 entity.getStatus() == EntityStatus.ACTIVE
         );

--- a/mark/src/main/java/pt/estga/mark/services/MarkServiceImpl.java
+++ b/mark/src/main/java/pt/estga/mark/services/MarkServiceImpl.java
@@ -28,23 +28,20 @@ public class MarkServiceImpl implements MarkService {
     private final MarkRepository markRepository;
     private final MarkOccurrenceRepository occurrenceRepository;
     private final MarkEvidenceRepository evidenceRepository;
-    private final MarkMapper markMapper;
-    private final MarkOccurrenceMapper occurrenceMapper;
-    private final MarkEvidenceMapper evidenceMapper;
 
     @Override
     public Optional<MarkDto> findMarkById(Long id) {
-        return markRepository.findById(id).map(markMapper::toDto);
+        return markRepository.findById(id).map(MarkMapper::toDto);
     }
 
     @Override
     public Optional<MarkOccurrenceDto> findOccurrenceById(Long id) {
-        return occurrenceRepository.findById(id).map(occurrenceMapper::toDto);
+        return occurrenceRepository.findById(id).map(MarkOccurrenceMapper::toDto);
     }
 
     @Override
     public Optional<MarkEvidenceDto> findEvidenceById(UUID id) {
-        return evidenceRepository.findById(id).map(evidenceMapper::toDto);
+        return evidenceRepository.findById(id).map(MarkEvidenceMapper::toDto);
     }
 
     @Override
@@ -72,14 +69,14 @@ public class MarkServiceImpl implements MarkService {
     public List<MarkEvidenceDto> findEvidenceWithEmbeddings(int limit) {
         var page = PageRequest.of(0, Math.max(1, limit));
         return evidenceRepository.findAllByEmbeddingIsNotNull(page).stream()
-                .map(evidenceMapper::toDto)
+                .map(MarkEvidenceMapper::toDto)
                 .toList();
     }
 
     @Override
     public List<MarkEvidenceDto> findEvidenceByIdIn(List<UUID> ids) {
         return evidenceRepository.findAllById(ids).stream()
-                .map(evidenceMapper::toDto)
+                .map(MarkEvidenceMapper::toDto)
                 .toList();
     }
 }

--- a/monument/src/main/java/pt/estga/monument/MonumentMapper.java
+++ b/monument/src/main/java/pt/estga/monument/MonumentMapper.java
@@ -1,6 +1,5 @@
 package pt.estga.monument;
 
-import org.springframework.stereotype.Component;
 import pt.estga.monument.dtos.MonumentDto;
 import pt.estga.monument.dtos.MonumentListDto;
 import pt.estga.monument.dtos.MonumentRequestDto;
@@ -9,10 +8,11 @@ import pt.estga.territory.dtos.AdministrativeDivisionDto;
 import pt.estga.territory.entities.AdministrativeDivision;
 import pt.estga.territory.utils.GeometryUtils;
 
-@Component
 public class MonumentMapper {
 
-    public MonumentDto toResponseDto(Monument monument) {
+    private MonumentMapper() {}
+
+    public static MonumentDto toResponseDto(Monument monument) {
         if (monument == null) return null;
         AdministrativeDivisionDto divisionDto = null;
         if (monument.getDivision() != null) {
@@ -38,7 +38,7 @@ public class MonumentMapper {
         );
     }
 
-    public MonumentListDto toListDto(Monument monument) {
+    public static MonumentListDto toListDto(Monument monument) {
         if (monument == null) return null;
         AdministrativeDivisionDto divisionDto = null;
         if (monument.getDivision() != null) {
@@ -55,7 +55,7 @@ public class MonumentMapper {
         );
     }
 
-    public Monument toEntity(MonumentRequestDto dto) {
+    public static Monument toEntity(MonumentRequestDto dto) {
         if (dto == null) return null;
         Monument monument = new Monument();
         monument.setName(dto.name());
@@ -74,7 +74,7 @@ public class MonumentMapper {
         return monument;
     }
 
-    public void updateEntityFromDto(MonumentRequestDto dto, Monument entity) {
+    public static void updateEntityFromDto(MonumentRequestDto dto, Monument entity) {
         if (dto == null || entity == null) return;
         entity.setName(dto.name());
         entity.setDescription(dto.description());

--- a/monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java
+++ b/monument/src/main/java/pt/estga/monument/controllers/MonumentAdminController.java
@@ -25,17 +25,16 @@ import java.net.URI;
 public class MonumentAdminController {
 
     private final MonumentService service;
-    private final MonumentMapper mapper;
 
     @PostMapping
     public ResponseEntity<MonumentDto> createMonument(
             @Parameter(description = "Monument form data", required = true)
             @Valid @ModelAttribute MonumentRequestDto monumentDto
     ) {
-        Monument monument = mapper.toEntity(monumentDto);
+        Monument monument = MonumentMapper.toEntity(monumentDto);
 
         Monument createdMonument = service.save(monument);
-        MonumentDto response = mapper.toResponseDto(createdMonument);
+        MonumentDto response = MonumentMapper.toResponseDto(createdMonument);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
@@ -55,10 +54,10 @@ public class MonumentAdminController {
         Monument existingMonument = service.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Monument not found"));
 
-        mapper.updateEntityFromDto(monumentDto, existingMonument);
+        MonumentMapper.updateEntityFromDto(monumentDto, existingMonument);
 
         Monument updatedMonument = service.save(existingMonument);
-        return ResponseEntity.ok(mapper.toResponseDto(updatedMonument));
+        return ResponseEntity.ok(MonumentMapper.toResponseDto(updatedMonument));
     }
 
     @DeleteMapping("/{id}")

--- a/monument/src/main/java/pt/estga/monument/controllers/MonumentController.java
+++ b/monument/src/main/java/pt/estga/monument/controllers/MonumentController.java
@@ -22,14 +22,13 @@ import pt.estga.monument.dtos.PolygonSearchRequest;
 public class MonumentController {
 
     private final MonumentService service;
-    private final MonumentMapper mapper;
 
     @GetMapping("/{id}")
     public ResponseEntity<MonumentDto> getMonumentById(
             @PathVariable Long id
     ) {
         return service.findById(id)
-                .map(mapper::toResponseDto)
+                .map(MonumentMapper::toResponseDto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
@@ -38,7 +37,7 @@ public class MonumentController {
     public ResponseEntity<Page<MonumentListDto>> findAll(
             @PageableDefault(size = 20) Pageable pageable
     ) {
-        return ResponseEntity.ok(service.findAll(pageable).map(mapper::toListDto));
+        return ResponseEntity.ok(service.findAll(pageable).map(MonumentMapper::toListDto));
     }
 
     @PostMapping(value = "/search/polygon", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -46,7 +45,7 @@ public class MonumentController {
             @Valid @RequestBody PolygonSearchRequest request,
             @PageableDefault(size = 9, sort = "name") Pageable pageable
     ) {
-        return ResponseEntity.ok(service.findByPolygon(request.geoJson(), pageable).map(mapper::toListDto));
+        return ResponseEntity.ok(service.findByPolygon(request.geoJson(), pageable).map(MonumentMapper::toListDto));
     }
 
     @GetMapping("/division/{id}")
@@ -54,6 +53,6 @@ public class MonumentController {
             @PathVariable Long id,
             @PageableDefault(size = 9, sort = "name") Pageable pageable
     ) {
-        return ResponseEntity.ok(service.findByDivisionId(id, pageable).map(mapper::toListDto));
+        return ResponseEntity.ok(service.findByDivisionId(id, pageable).map(MonumentMapper::toListDto));
     }
 }

--- a/processing/src/main/java/pt/estga/processing/mappers/MarkSuggestionMapper.java
+++ b/processing/src/main/java/pt/estga/processing/mappers/MarkSuggestionMapper.java
@@ -1,13 +1,13 @@
 package pt.estga.processing.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.processing.dtos.MarkSuggestionDto;
 import pt.estga.processing.entities.MarkSuggestion;
 
-@Component
 public class MarkSuggestionMapper {
 
-    public MarkSuggestionDto toDto(MarkSuggestion suggestion) {
+    private MarkSuggestionMapper() {}
+
+    public static MarkSuggestionDto toDto(MarkSuggestion suggestion) {
         if (suggestion == null) return null;
         MarkSuggestionDto dto = new MarkSuggestionDto();
         dto.setId(suggestion.getId());

--- a/processing/src/main/java/pt/estga/processing/services/processing/SuggestionQueryService.java
+++ b/processing/src/main/java/pt/estga/processing/services/processing/SuggestionQueryService.java
@@ -18,13 +18,12 @@ public class SuggestionQueryService {
 
     private final MarkEvidenceProcessingRepository processingRepository;
     private final MarkSuggestionRepository suggestionRepository;
-    private final MarkSuggestionMapper suggestionMapper;
 
     public Optional<List<MarkSuggestionDto>> findSuggestionsBySubmissionId(Long submissionId) {
         return processingRepository.findBySubmissionId(submissionId)
                 .map(p -> suggestionRepository.findByProcessingId(p.getId())
                         .stream()
-                        .map(suggestionMapper::toDto)
+                        .map(MarkSuggestionMapper::toDto)
                         .toList());
     }
 }

--- a/review/src/main/java/pt/estga/review/controllers/ReviewController.java
+++ b/review/src/main/java/pt/estga/review/controllers/ReviewController.java
@@ -25,7 +25,6 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewService reviewService;
-    private final ReviewMapper mapper;
 
     @PostMapping("/{submissionId}/accept")
     @ResponseStatus(HttpStatus.CREATED)
@@ -36,7 +35,7 @@ public class ReviewController {
             @RequestBody(required = false) SimpleReviewRequest request) {
 
         var comment = request != null ? request.comment() : null;
-        return mapper.toDto(reviewService.acceptSuggestion(submissionId, markId, comment));
+        return ReviewMapper.toDto(reviewService.acceptSuggestion(submissionId, markId, comment));
     }
 
     @PostMapping("/{submissionId}/accept-as-new")
@@ -46,7 +45,7 @@ public class ReviewController {
             @PathVariable Long submissionId,
             @Valid @RequestBody AcceptNewMarkRequest request) {
 
-        return mapper.toDto(reviewService.acceptAsNew(submissionId, request.markTitle(), request.comment()));
+        return ReviewMapper.toDto(reviewService.acceptAsNew(submissionId, request.markTitle(), request.comment()));
     }
 
     @PostMapping("/{submissionId}/reject")
@@ -57,7 +56,7 @@ public class ReviewController {
             @RequestBody(required = false) SimpleReviewRequest request) {
 
         var comment = request != null ? request.comment() : null;
-        return mapper.toDto(reviewService.rejectAll(submissionId, comment));
+        return ReviewMapper.toDto(reviewService.rejectAll(submissionId, comment));
     }
 
     @GetMapping("/{submissionId}")

--- a/review/src/main/java/pt/estga/review/mappers/ReviewMapper.java
+++ b/review/src/main/java/pt/estga/review/mappers/ReviewMapper.java
@@ -1,13 +1,13 @@
 package pt.estga.review.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.review.dtos.ReviewResponseDto;
 import pt.estga.review.entities.MarkEvidenceReview;
 
-@Component
 public class ReviewMapper {
 
-    public ReviewResponseDto toDto(MarkEvidenceReview review) {
+    private ReviewMapper() {}
+
+    public static ReviewResponseDto toDto(MarkEvidenceReview review) {
         if (review == null) return null;
         String reviewerName = review.getReviewedBy() != null
                 ? review.getReviewedBy().getFirstName() + " " + review.getReviewedBy().getLastName()

--- a/review/src/main/java/pt/estga/review/services/ReviewService.java
+++ b/review/src/main/java/pt/estga/review/services/ReviewService.java
@@ -31,8 +31,7 @@ public class ReviewService {
 
  	private final MarkEvidenceSubmissionRepository submissionRepository;
  	private final MarkEvidenceProcessingRepository processingRepository;
-	private final MarkSuggestionRepository suggestionRepository;
-	private final MarkSuggestionMapper suggestionMapper;
+ 	private final MarkSuggestionRepository suggestionRepository;
   	private final MarkEvidenceReviewRepository markEvidenceReviewRepository;
 	private final List<ReviewProcessor> processors;
 	private final ReviewExecutor executor;
@@ -122,7 +121,7 @@ public class ReviewService {
 		return processingRepository.findBySubmissionId(submissionId)
 				.map(p -> suggestionRepository.findByProcessingId(p.getId())
 						.stream()
-						.map(suggestionMapper::toDto)
+						.map(MarkSuggestionMapper::toDto)
 						.toList())
 				.orElseThrow(() -> new ResourceNotFoundException("Suggestions not found"));
 	}

--- a/review/src/test/java/pt/estga/review/services/ReviewServiceTest.java
+++ b/review/src/test/java/pt/estga/review/services/ReviewServiceTest.java
@@ -11,7 +11,6 @@ import pt.estga.intake.repositories.MarkEvidenceSubmissionRepository;
 import pt.estga.mark.entities.Mark;
 import pt.estga.processing.enums.ProcessingStatus;
 import pt.estga.processing.repositories.projections.ProcessingOverviewProjection;
-import pt.estga.processing.mappers.MarkSuggestionMapper;
 import pt.estga.processing.repositories.MarkEvidenceProcessingRepository;
 import pt.estga.processing.repositories.MarkSuggestionRepository;
 import pt.estga.review.entities.MarkEvidenceReview;
@@ -53,9 +52,6 @@ public class ReviewServiceTest {
     @Mock
     MarkEvidenceReviewRepository markEvidenceReviewRepository;
 
-    @Mock
-    MarkSuggestionMapper suggestionMapper;
-
     ReviewService reviewService;
 
     @BeforeEach
@@ -68,7 +64,6 @@ public class ReviewServiceTest {
                 submissionRepository,
                 markEvidenceProcessingRepository,
                 suggestionRepository,
-                suggestionMapper,
                 markEvidenceReviewRepository,
                 List.of(processor),
                 executor

--- a/support/src/main/java/pt/estga/support/mappers/ContactRequestMapper.java
+++ b/support/src/main/java/pt/estga/support/mappers/ContactRequestMapper.java
@@ -1,13 +1,13 @@
 package pt.estga.support.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.support.dtos.ContactRequestDto;
 import pt.estga.support.entities.ContactRequest;
 
-@Component
 public class ContactRequestMapper {
 
-    public ContactRequest toEntity(ContactRequestDto dto) {
+    private ContactRequestMapper() {}
+
+    public static ContactRequest toEntity(ContactRequestDto dto) {
         if (dto == null) return null;
         ContactRequest entity = new ContactRequest();
         entity.setName(dto.name());

--- a/support/src/main/java/pt/estga/support/services/ContactRequestService.java
+++ b/support/src/main/java/pt/estga/support/services/ContactRequestService.java
@@ -21,11 +21,10 @@ import java.util.Optional;
 public class ContactRequestService {
 
     private final ContactRequestRepository repository;
-    private final ContactRequestMapper mapper;
 
     @Transactional
     public ContactRequest create(ContactRequestDto dto) {
-        ContactRequest contact = mapper.toEntity(dto);
+        ContactRequest contact = ContactRequestMapper.toEntity(dto);
         contact.setStatus(ContactStatus.PENDING);
         contact.setCreatedAt(Instant.now());
         return repository.save(contact);

--- a/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
+++ b/territory/src/main/java/pt/estga/territory/controllers/AdministrativeDivisionController.java
@@ -20,11 +20,10 @@ import java.util.List;
 public class AdministrativeDivisionController {
 
     private final DivisionService service;
-    private final AdministrativeDivisionMapper mapper;
 
     @GetMapping("/roots")
     public ResponseEntity<List<AdministrativeDivisionDto>> getRoots() {
-        return ResponseEntity.ok(mapper.toDtoList(service.findRoots()));
+        return ResponseEntity.ok(AdministrativeDivisionMapper.toDtoList(service.findRoots()));
     }
 
     @GetMapping
@@ -35,27 +34,27 @@ public class AdministrativeDivisionController {
     @GetMapping("/{id}")
     public ResponseEntity<AdministrativeDivisionDto> getById(@PathVariable Long id) {
         return service.findById(id)
-                .map(mapper::toDto)
+                .map(AdministrativeDivisionMapper::toDto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/{id}/children")
     public ResponseEntity<List<AdministrativeDivisionDto>> getChildren(@PathVariable Long id) {
-        return ResponseEntity.ok(mapper.toDtoList(service.findChildren(id)));
+        return ResponseEntity.ok(AdministrativeDivisionMapper.toDtoList(service.findChildren(id)));
     }
 
     @GetMapping("/{id}/parent")
     public ResponseEntity<AdministrativeDivisionDto> getParent(@PathVariable Long id) {
         return service.findParent(id)
-                .map(mapper::toDto)
+                .map(AdministrativeDivisionMapper::toDto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }
 
     @GetMapping("/{id}/ancestors")
     public ResponseEntity<List<AdministrativeDivisionDto>> getAncestors(@PathVariable Long id) {
-        return ResponseEntity.ok(mapper.toDtoList(service.findAncestors(id)));
+        return ResponseEntity.ok(AdministrativeDivisionMapper.toDtoList(service.findAncestors(id)));
     }
 
     @GetMapping("/coordinates")
@@ -63,6 +62,6 @@ public class AdministrativeDivisionController {
             @RequestParam double latitude,
             @RequestParam double longitude
     ) {
-        return ResponseEntity.ok(mapper.toDtoList(service.findByCoordinates(latitude, longitude)));
+        return ResponseEntity.ok(AdministrativeDivisionMapper.toDtoList(service.findByCoordinates(latitude, longitude)));
     }
 }

--- a/territory/src/main/java/pt/estga/territory/mappers/AdministrativeDivisionMapper.java
+++ b/territory/src/main/java/pt/estga/territory/mappers/AdministrativeDivisionMapper.java
@@ -1,15 +1,15 @@
 package pt.estga.territory.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.territory.dtos.AdministrativeDivisionDto;
 import pt.estga.territory.entities.AdministrativeDivision;
 
 import java.util.List;
 
-@Component
 public class AdministrativeDivisionMapper {
 
-    public AdministrativeDivisionDto toDto(AdministrativeDivision entity) {
+    private AdministrativeDivisionMapper() {}
+
+    public static AdministrativeDivisionDto toDto(AdministrativeDivision entity) {
         if (entity == null) return null;
         return new AdministrativeDivisionDto(
                 entity.getId(),
@@ -19,8 +19,8 @@ public class AdministrativeDivisionMapper {
         );
     }
 
-    public List<AdministrativeDivisionDto> toDtoList(List<AdministrativeDivision> entities) {
+    public static List<AdministrativeDivisionDto> toDtoList(List<AdministrativeDivision> entities) {
         if (entities == null) return List.of();
-        return entities.stream().map(this::toDto).toList();
+        return entities.stream().map(AdministrativeDivisionMapper::toDto).toList();
     }
 }

--- a/territory/src/main/java/pt/estga/territory/services/DivisionService.java
+++ b/territory/src/main/java/pt/estga/territory/services/DivisionService.java
@@ -25,10 +25,9 @@ import java.util.Optional;
 public class DivisionService {
 	
   	private final AdministrativeDivisionRepository repository;
-	private final AdministrativeDivisionMapper mapper;
 
 	public Page<AdministrativeDivisionDto> findAll(Pageable pageable) {
-		return repository.findAll(pageable).map(mapper::toDto);
+		return repository.findAll(pageable).map(AdministrativeDivisionMapper::toDto);
 	}
 
 	public Optional<AdministrativeDivision> findById(Long id) {

--- a/user/src/main/java/pt/estga/user/controllers/UserPublicController.java
+++ b/user/src/main/java/pt/estga/user/controllers/UserPublicController.java
@@ -19,14 +19,13 @@ import pt.estga.user.services.UserService;
 public class UserPublicController {
 
     private final UserService service;
-    private final UserMapper mapper;
 
     @GetMapping("/{id}")
     public ResponseEntity<UserPublicDto> publicGetById(
             @Parameter(description = "ID of the user to be retrieved", required = true)
             @PathVariable Long id) {
         return service.findById(id)
-                .map(mapper::toPublicDto)
+                .map(UserMapper::toPublicDto)
                 .map(ResponseEntity::ok)
                 .orElse(ResponseEntity.notFound().build());
     }

--- a/user/src/main/java/pt/estga/user/mappers/UserMapper.java
+++ b/user/src/main/java/pt/estga/user/mappers/UserMapper.java
@@ -1,6 +1,5 @@
 package pt.estga.user.mappers;
 
-import org.springframework.stereotype.Component;
 import pt.estga.user.dtos.ProfileUpdateRequestDto;
 import pt.estga.user.dtos.UserPublicDto;
 import pt.estga.user.dtos.UserDto;
@@ -10,10 +9,11 @@ import pt.estga.user.entities.User;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Component
 public class UserMapper {
 
-    public UserDto toDto(User user) {
+    private UserMapper() {}
+
+    public static UserDto toDto(User user) {
         if (user == null) return null;
         Set<String> roleNames = user.getRoles().stream()
                 .map(Role::getName)
@@ -30,7 +30,7 @@ public class UserMapper {
         );
     }
 
-    public UserPublicDto toPublicDto(User user) {
+    public static UserPublicDto toPublicDto(User user) {
         if (user == null) return null;
         return new UserPublicDto(
                 user.getId(),
@@ -41,7 +41,7 @@ public class UserMapper {
         );
     }
 
-    public void update(User source, User target) {
+    public static void update(User source, User target) {
         if (source == null || target == null) return;
         target.setFirstName(source.getFirstName());
         target.setLastName(source.getLastName());
@@ -49,13 +49,13 @@ public class UserMapper {
         target.setEmail(source.getEmail());
     }
 
-    public void update(User user, ProfileUpdateRequestDto dto) {
+    public static void update(User user, ProfileUpdateRequestDto dto) {
         if (user == null || dto == null) return;
         user.setFirstName(dto.firstName());
         user.setLastName(dto.lastName());
     }
 
-    public void updateFromDto(UserDto dto, User user) {
+    public static void updateFromDto(UserDto dto, User user) {
         if (dto == null || user == null) return;
         user.setFirstName(dto.firstName());
         user.setLastName(dto.lastName());

--- a/user/src/main/java/pt/estga/user/services/UserLookupAdapter.java
+++ b/user/src/main/java/pt/estga/user/services/UserLookupAdapter.java
@@ -14,10 +14,9 @@ import java.util.Optional;
 public class UserLookupAdapter implements UserLookupOperations {
 
     private final UserRepository userRepository;
-    private final UserMapper userMapper;
 
     @Override
     public Optional<UserDto> findById(Long id) {
-        return userRepository.findById(id).map(userMapper::toDto);
+        return userRepository.findById(id).map(UserMapper::toDto);
     }
 }

--- a/user/src/main/java/pt/estga/user/services/UserService.java
+++ b/user/src/main/java/pt/estga/user/services/UserService.java
@@ -24,12 +24,11 @@ public class UserService {
 
     private final UserRepository repository;
     private final ChatbotAccountRepository chatbotAccountRepository;
-    private final UserMapper mapper;
     private final AuthenticationService authenticationService;
     private final PasswordEncoder passwordEncoder;
 
     public Page<UserDto> findAll(Pageable pageable) {
-        return repository.findAll(pageable).map(mapper::toDto);
+        return repository.findAll(pageable).map(UserMapper::toDto);
     }
 
     public Optional<User> findById(Long id) {
@@ -37,7 +36,7 @@ public class UserService {
     }
 
     public Optional<UserDto> findDtoById(Long id) {
-        return repository.findById(id).map(mapper::toDto);
+        return repository.findById(id).map(UserMapper::toDto);
     }
 
     public Optional<User> findByEmail(String email) {
@@ -64,7 +63,7 @@ public class UserService {
         }
         User existing = repository.findById(user.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("User with id " + user.getId() + " not found"));
-        mapper.update(user, existing);
+        UserMapper.update(user, existing);
         User saved = repository.save(existing);
         authenticationService.invalidateCache(saved.getId());
         return saved;
@@ -77,10 +76,10 @@ public class UserService {
         }
         User existing = repository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("User with id " + id + " not found"));
-        mapper.updateFromDto(dto, existing);
+        UserMapper.updateFromDto(dto, existing);
         User saved = repository.save(existing);
         authenticationService.invalidateCache(saved.getId());
-        return mapper.toDto(saved);
+        return UserMapper.toDto(saved);
     }
 
     @Transactional
@@ -99,7 +98,7 @@ public class UserService {
     public UserDto getProfile(Long userId) {
         User user = repository.findByIdForProfile(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
-        return mapper.toDto(user);
+        return UserMapper.toDto(user);
     }
 
     public MeDto getMe(Long userId) {
@@ -121,7 +120,7 @@ public class UserService {
     public void updateProfile(Long userId, ProfileUpdateRequestDto request) {
         User user = repository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found with id: " + userId));
-        mapper.update(user, request);
+        UserMapper.update(user, request);
         repository.save(user);
         authenticationService.invalidateCache(user.getId());
     }


### PR DESCRIPTION
This pull request refactors several mapper classes across multiple modules to use static methods instead of instance methods, and updates their usage throughout the codebase. This change removes the need to inject mappers as dependencies, simplifying constructors and improving consistency. Additionally, related test and controller code is updated to match the new static usage.

**Mapper Refactoring and Static Method Adoption:**

* Converted `MonumentMapper`, `MediaFileMapper`, `MarkMapper`, `MarkOccurrenceMapper`, `MarkEvidenceMapper`, and `MarkSuggestionMapper` to use static methods. Removed `@Component` annotations and private constructors were added to prevent instantiation. [[1]](diffhunk://#diff-18b1a290a52bcce9e97691b824a6e16b7f2d1ffe7c86861c9dec6bff50a45a2aL3) [[2]](diffhunk://#diff-18b1a290a52bcce9e97691b824a6e16b7f2d1ffe7c86861c9dec6bff50a45a2aL12-R15) [[3]](diffhunk://#diff-18b1a290a52bcce9e97691b824a6e16b7f2d1ffe7c86861c9dec6bff50a45a2aL41-R41) [[4]](diffhunk://#diff-18b1a290a52bcce9e97691b824a6e16b7f2d1ffe7c86861c9dec6bff50a45a2aL58-R58) [[5]](diffhunk://#diff-18b1a290a52bcce9e97691b824a6e16b7f2d1ffe7c86861c9dec6bff50a45a2aL77-R77) [[6]](diffhunk://#diff-83802517cb9155ba9cdfbf894cb44339a40bf3f10142f8d8ffa05736d261d36cL3-R10) [[7]](diffhunk://#diff-4a40f5ddce26b73f01dbc87f70c875b8552a492e9e9c7722b9d56770c31d666dL3-R10) [[8]](diffhunk://#diff-133d4423cf85be857ad8757881660ac511f3c853954384da5074792157753912L3-R11) [[9]](diffhunk://#diff-3c26eebc2cfdf87d47bde587e094414b60f2bab93fa959ac2eaf84ca2445f540L3-R17) [[10]](diffhunk://#diff-a8d03a2e8519fcc1b422a1753dd9baebfb04b87beaa8481676a25fc19001bde8L3-R10)

**Service and Controller Updates:**

* Updated all usages of the affected mappers in services and controllers to use static method calls (e.g., `MonumentMapper.toResponseDto(...)` instead of `mapper.toResponseDto(...)`). This includes `MonumentAdminController`, `MonumentController`, `MarkServiceImpl`, `MediaController`, `FileStorageAdapter`, and `SuggestionQueryService`. [[1]](diffhunk://#diff-265025cb12a0f22d2c107753c673fbdfe7ff47fddca0946ad3712ce1f9228a0bL28-R37) [[2]](diffhunk://#diff-265025cb12a0f22d2c107753c673fbdfe7ff47fddca0946ad3712ce1f9228a0bL58-R60) [[3]](diffhunk://#diff-53d639a5b6847f82952c39dc84ea7ecbbc7b3b80f4b85a799e7615243a8fadfaL25-R31) [[4]](diffhunk://#diff-53d639a5b6847f82952c39dc84ea7ecbbc7b3b80f4b85a799e7615243a8fadfaL41-R56) [[5]](diffhunk://#diff-c0925e69503d26bd9da4f86976bba2f88284b5261e2b8c170fb54de39fcb301eL31-R44) [[6]](diffhunk://#diff-c0925e69503d26bd9da4f86976bba2f88284b5261e2b8c170fb54de39fcb301eL75-R79) [[7]](diffhunk://#diff-b0383e80dab33fb7457ad35888c3ebbefb826bc04692c37aeb53f182affa7bdcL58-R57) [[8]](diffhunk://#diff-88aef932c89abc82bfe392e453fb6df36f99d62a3e2e59da21eee381a9c98d8cL25-R32) [[9]](diffhunk://#diff-88aef932c89abc82bfe392e453fb6df36f99d62a3e2e59da21eee381a9c98d8cL52-R51) [[10]](diffhunk://#diff-88aef932c89abc82bfe392e453fb6df36f99d62a3e2e59da21eee381a9c98d8cL61-R60) [[11]](diffhunk://#diff-db87c825d38dec55362bef5a235d4a64e33873bd8b6930bf561ba001377b4b78L21-R26) [[12]](diffhunk://#diff-83f378f4553ba9a98b366b9aa3934c8b08719f98c2d853d12e8d6437b2788ad3L50-R49)

**Dependency Injection and Constructor Simplification:**

* Removed mapper fields from constructors and class fields where they are no longer needed, simplifying dependency injection and reducing boilerplate. [[1]](diffhunk://#diff-b0383e80dab33fb7457ad35888c3ebbefb826bc04692c37aeb53f182affa7bdcL39) [[2]](diffhunk://#diff-88aef932c89abc82bfe392e453fb6df36f99d62a3e2e59da21eee381a9c98d8cL25-R32) [[3]](diffhunk://#diff-265025cb12a0f22d2c107753c673fbdfe7ff47fddca0946ad3712ce1f9228a0bL28-R37) [[4]](diffhunk://#diff-53d639a5b6847f82952c39dc84ea7ecbbc7b3b80f4b85a799e7615243a8fadfaL25-R31) [[5]](diffhunk://#diff-c0925e69503d26bd9da4f86976bba2f88284b5261e2b8c170fb54de39fcb301eL31-R44) [[6]](diffhunk://#diff-db87c825d38dec55362bef5a235d4a64e33873bd8b6930bf561ba001377b4b78L21-R26) [[7]](diffhunk://#diff-83f378f4553ba9a98b366b9aa3934c8b08719f98c2d853d12e8d6437b2788ad3L24)

**Test Code Adjustments:**

* Updated test code to remove unnecessary mocks and constructor arguments for mappers, particularly in `MediaControllerTest`. [[1]](diffhunk://#diff-b12abf923a4bd7c6e9f5c89aa10ea26d5ffc488b4a3d60c2ceeb40ba691f9e56L13) [[2]](diffhunk://#diff-b12abf923a4bd7c6e9f5c89aa10ea26d5ffc488b4a3d60c2ceeb40ba691f9e56L31-R32) [[3]](diffhunk://#diff-b12abf923a4bd7c6e9f5c89aa10ea26d5ffc488b4a3d60c2ceeb40ba691f9e56L46)

**General Codebase Cleanup:**

* Removed unused imports and annotations related to the mappers, further cleaning up the code. [[1]](diffhunk://#diff-18b1a290a52bcce9e97691b824a6e16b7f2d1ffe7c86861c9dec6bff50a45a2aL3) [[2]](diffhunk://#diff-4a40f5ddce26b73f01dbc87f70c875b8552a492e9e9c7722b9d56770c31d666dL3-R10) [[3]](diffhunk://#diff-133d4423cf85be857ad8757881660ac511f3c853954384da5074792157753912L3-R11) [[4]](diffhunk://#diff-3c26eebc2cfdf87d47bde587e094414b60f2bab93fa959ac2eaf84ca2445f540L3-R17) [[5]](diffhunk://#diff-a8d03a2e8519fcc1b422a1753dd9baebfb04b87beaa8481676a25fc19001bde8L3-R10) [[6]](diffhunk://#diff-b12abf923a4bd7c6e9f5c89aa10ea26d5ffc488b4a3d60c2ceeb40ba691f9e56L13)

Overall, this refactor reduces dependency complexity, makes mapper usage more consistent, and slightly improves performance by removing unnecessary bean creation.